### PR TITLE
wdi: bump version to build with stable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,7 +508,7 @@ dependencies = [
 [[package]]
 name = "libwdi-sys"
 version = "0.1.0"
-source = "git+https://github.com/blackmagic-debug/wdi-rs#9b297e64fa51b217d3077cd759f7b6222c07cf28"
+source = "git+https://github.com/blackmagic-debug/wdi-rs#6fa604b64f39a26d1ec4fec26239f04d5a8933b1"
 dependencies = [
  "bindgen",
  "cc",
@@ -1171,7 +1171,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 [[package]]
 name = "wdi"
 version = "0.1.0"
-source = "git+https://github.com/blackmagic-debug/wdi-rs#9b297e64fa51b217d3077cd759f7b6222c07cf28"
+source = "git+https://github.com/blackmagic-debug/wdi-rs#6fa604b64f39a26d1ec4fec26239f04d5a8933b1"
 dependencies = [
  "bstr",
  "libwdi-sys",


### PR DESCRIPTION
With 6fa604b64f39a26d1ec4fec26239f04d5a8933b1 this program can now be built with a `stable` version of Rust. This simply bumps the version of `libwdi-sys` (and `wdi`) that are used. With this patch, `bmputil` can be built on stable and no longer requires nightly.