### PR TITLE
Fix: update clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,21 +12,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c4c2c83f81532e5845a733998b6971faca23490340a418e9b72a3ec9de12ea"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "autocfg"
@@ -165,26 +202,35 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.25"
+version = "4.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
+checksum = "1d5f1946157a96594eb2d2c10eb7ad9a2b27518cb3000209dec700c35df9197d"
 dependencies = [
- "atty",
- "bitflags 1.3.2",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78116e32a042dd73c2901f0dc30790d20ff3447f3e3472fad359e8c3d282bcd6"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "indexmap",
- "termcolor",
- "textwrap",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "console"
@@ -418,21 +464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,16 +480,6 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
 
 [[package]]
 name = "indicatif"
@@ -488,7 +509,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -535,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "libwdi-sys"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ef3399d12c1d7395b1f5babff8a715bd5c062283d823eb1f23eddbe2c56d80b"
+checksum = "e6611a6fbafc5bdf80ab4d2e6be9a63da1d5148f2e9bde3c727c491d1813abbe"
 dependencies = [
  "bindgen",
  "cc",
@@ -655,12 +676,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "os_str_bytes"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,9 +759,9 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f32154ba0af3a075eefa1eda8bb414ee928f62303a54ea85b8d6638ff1a6ee9e"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
 
 [[package]]
 name = "ppv-lite86"
@@ -869,9 +884,9 @@ checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "rusb"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44a8c36914f9b1a3be712c1dfa48c9b397131f9a75707e570a391735f785c5d1"
+checksum = "45fff149b6033f25e825cbb7b2c625a11ee8e6dac09264d49beb125e39aa97bf"
 dependencies = [
  "libc",
  "libusb1-sys",
@@ -894,9 +909,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "9bfe0f2582b4931a45d1fa608f8a8722e8b3c7ac54dd6d5f3b3212791fedef49"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
@@ -951,18 +966,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.186"
+version = "1.0.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
+checksum = "30a7fe14252655bd1e578af19f5fa00fe02fd0013b100ca6b49fde31c41bae4c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.186"
+version = "1.0.187"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
+checksum = "e46b2a6ca578b3f1d4501b12f78ed4692006d79d82a1a7c561c12dbc3d625eb8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1113,12 +1128,6 @@ dependencies = [
  "vtparse",
  "winapi",
 ]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ dependencies = [
 name = "bmputil"
 version = "0.1.0"
 dependencies = [
+ "anstyle",
  "anyhow",
  "bstr",
  "clap",
@@ -218,6 +219,10 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
+ "once_cell",
+ "terminal_size",
+ "unicase",
+ "unicode-width",
 ]
 
 [[package]]
@@ -504,13 +509,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-lifetimes"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "rustix 0.38.9",
  "windows-sys 0.48.0",
 ]
 
@@ -567,6 +583,12 @@ dependencies = [
  "log",
  "winapi",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
@@ -909,6 +931,20 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.37.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+dependencies = [
+ "bitflags 1.3.2",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys 0.3.8",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "rustix"
 version = "0.38.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bfe0f2582b4931a45d1fa608f8a8722e8b3c7ac54dd6d5f3b3212791fedef49"
@@ -916,7 +952,7 @@ dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -1076,6 +1112,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6bf6f19e9f8ed8d4048dc22981458ebcf406d67e94cd422e5ecd73d63b3237"
+dependencies = [
+ "rustix 0.37.23",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "terminfo"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1160,6 +1206,15 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
+
+[[package]]
+name = "unicase"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d2d4dafb69621809a81864c9c1b864479e1235c0dd4e199924b9742439ed89"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bmputil"
+description = "Black Magic Probe Firmware Manager"
 version = "0.1.0"
 edition = "2021"
 
@@ -15,7 +16,7 @@ default = ["detect-backtrace", "vendored"]
 
 [dependencies]
 anstyle = "1.0.2"
-clap = { version = "4.0", default-features = false, features = ["std", "color", "help", "usage", "unicode", "wrap_help", "unstable-styles"] }
+clap = { version = "4.0", default-features = false, features = ["std", "color", "help", "usage", "unicode", "wrap_help", "unstable-styles", "cargo"] }
 env_logger = "0.10"
 dfu-core = { version = "0.6.0", features = ["std"] }
 dfu-libusb = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ vendored = ["rusb/vendored"]
 default = ["detect-backtrace", "vendored"]
 
 [dependencies]
-clap = { version = "4.0", default-features = false, features = ["std", "color"] }
+clap = { version = "4.0", default-features = false, features = ["std", "color", "help", "usage"] }
 env_logger = "0.10"
 dfu-core = { version = "0.6.0", features = ["std"] }
 dfu-libusb = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,8 @@ vendored = ["rusb/vendored"]
 default = ["detect-backtrace", "vendored"]
 
 [dependencies]
-clap = { version = "4.0", default-features = false, features = ["std", "color", "help", "usage"] }
+anstyle = "1.0.2"
+clap = { version = "4.0", default-features = false, features = ["std", "color", "help", "usage", "unicode", "wrap_help", "unstable-styles"] }
 env_logger = "0.10"
 dfu-core = { version = "0.6.0", features = ["std"] }
 dfu-libusb = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ vendored = ["rusb/vendored"]
 default = ["detect-backtrace", "vendored"]
 
 [dependencies]
-clap = { version = "3.0", default-features = false, features = ["std", "color"] }
+clap = { version = "4.0", default-features = false, features = ["std", "color"] }
 env_logger = "0.10"
 dfu-core = { version = "0.6.0", features = ["std"] }
 dfu-libusb = "0.5.1"

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -5,7 +5,6 @@ use std::mem;
 use std::thread;
 use std::io::Read;
 use std::cell::{RefCell, Ref, RefMut};
-use std::str::FromStr;
 use std::time::{Duration, Instant};
 use std::fmt::{self, Display, Formatter};
 use std::array::TryFromSliceError;
@@ -772,9 +771,9 @@ impl BmpMatcher
     pub(crate) fn from_cli_args(matches: &ArgMatches) -> Self
     {
         Self::new()
-            .index(matches.value_of("index").map(|arg| usize::from_str(arg).unwrap()))
-            .serial(matches.value_of("serial_number"))
-            .port(matches.value_of("port"))
+            .index(matches.get_one::<usize>("index").map(|&value| value))
+            .serial(matches.get_one::<String>("serial_number").map(|s| s.as_str()))
+            .port(matches.get_one::<String>("port").map(|s| s.as_str()))
     }
 
     /// Set the index to match against.

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,9 @@ use std::io::Read;
 use std::str::FromStr;
 use std::time::Duration;
 
+use anstyle;
 use clap::ArgAction;
+use clap::builder::styling::Styles;
 use clap::{Command, Arg, ArgMatches};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use indicatif::{ProgressBar, ProgressStyle};
@@ -265,6 +267,25 @@ fn info_command(matches: &ArgMatches) -> Result<(), Error>
     Ok(())
 }
 
+/// Clap v3 style (approximate)
+/// See https://stackoverflow.com/a/75343828
+fn style() -> clap::builder::Styles {
+    Styles::styled()
+        .usage(
+            anstyle::Style::new()
+                .fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Yellow)))
+                .bold(),
+        )
+        .header(
+            anstyle::Style::new()
+                .bold()
+                .fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Yellow))),
+        )
+        .literal(
+            anstyle::Style::new().fg_color(Some(anstyle::Color::Ansi(anstyle::AnsiColor::Green))),
+        )
+}
+
 fn main()
 {
     env_logger::Builder::new()
@@ -285,6 +306,8 @@ fn main()
             );
     }
     parser = parser
+        .styles(style())
+        .disable_colored_help(false)
         .arg_required_else_help(true)
         .arg(Arg::new("serial_number")
             .short('s')

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,9 +13,8 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anstyle;
-use clap::ArgAction;
+use clap::{ArgAction, Command, Arg, ArgMatches, crate_version, crate_description, crate_name};
 use clap::builder::styling::Styles;
-use clap::{Command, Arg, ArgMatches};
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use indicatif::{ProgressBar, ProgressStyle};
 use log::{debug, warn, error};
@@ -293,7 +292,7 @@ fn main()
         .parse_default_env()
         .init();
 
-    let mut parser = Command::new("Black Magic Probe Firmware Manager");
+    let mut parser = Command::new(crate_name!());
     if cfg!(windows) {
         parser = parser
             .arg(Arg::new("windows-wdi-install-mode")
@@ -306,6 +305,8 @@ fn main()
             );
     }
     parser = parser
+        .about(crate_description!())
+        .version(crate_version!())
         .styles(style())
         .disable_colored_help(false)
         .arg_required_else_help(true)

--- a/src/main.rs
+++ b/src/main.rs
@@ -389,14 +389,13 @@ fn main()
             "debug" => match subcommand_matches.subcommand() {
                 Some(("install-drivers", install_driver_matches)) => {
 
-                    let wdi_install_parent_pid: Option<u32> = matches
-                        .value_of("windows-wdi-install-mode")
-                        .map(|v| v.parse().unwrap());
+                    let wdi_install_parent_pid: Option<&u32> = matches
+                        .get_one::<u32>("windows-wdi-install-mode");
 
-                    let force: bool = install_driver_matches.is_present("force");
+                    let force: bool = install_driver_matches.contains_id("force");
 
                     windows::ensure_access(
-                        wdi_install_parent_pid,
+                        wdi_install_parent_pid.copied(),
                         true, // explicitly_requested.
                         force,
                     );
@@ -410,8 +409,8 @@ fn main()
         // Otherwise, potentially install drivers, but still do whatever else the user wanted.
         windows::ensure_access(
             matches
-                .value_of("windows-wdi-install-mode")
-                .map(|v| v.parse().unwrap()),
+                .get_one::<u32>("windows-wdi-install-mode")
+                .copied(),
             false, // explicitly_requested
             false, // force
         );


### PR DESCRIPTION
This PR updates the Clap crate from 3 => 4, solving the `atty` dependabot problem and clearing the way for the tool to be published to crates.io soon.

This is with thanks to Amy for helping us complete the conversion and figure out all the ways things got broken along the way.