### PR TITLE
cargo: fix unmatched bmputil version in cargo lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "bmputil"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anstyle",
  "anyhow",


### PR DESCRIPTION
This partially fixes #18, but the release archive still needs correcting