### PR TITLE
Fix: Updated dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-target
+target/
+/.vscode/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "editor.insertSpaces": true,
-    "files.eol": "\n",
-    "files.insertFinalNewline": true,
-    "rust-analyzer.imports.granularity.group": "preserve"
-}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.77",
+ "syn 2.0.99",
  "which",
 ]
 
@@ -144,7 +144,7 @@ dependencies = [
  "rustc_version",
  "static_vcruntime",
  "termcolor",
- "thiserror",
+ "thiserror 2.0.12",
  "wdi",
  "winapi",
  "winreg",
@@ -309,7 +309,7 @@ dependencies = [
  "displaydoc",
  "log",
  "pretty-hex",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -320,7 +320,7 @@ checksum = "4664041609496e84cca3a0fcd48a4586b7029d93dbb4b89191854de5d1d47043"
 dependencies = [
  "dfu-core",
  "rusb",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -369,7 +369,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -437,7 +437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7199d965852c3bac31f779ef99cbb4537f80e952e2d6aa0ffeb30cce00f4f46e"
 dependencies = [
  "libc",
- "thiserror",
+ "thiserror 1.0.64",
  "winapi",
 ]
 
@@ -751,7 +751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdbef9d1d47087a895abd220ed25eb4ad973a5e26f6a4367b038c25e28dfc2d9"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.64",
  "ucd-trie",
 ]
 
@@ -833,14 +833,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479cf940fbbb3426c32c5d5176f62ad57549a0bb84773423ba8be9d089f5faba"
 dependencies = [
  "proc-macro2",
- "syn 2.0.77",
+ "syn 2.0.99",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.86"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
@@ -892,7 +892,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.64",
 ]
 
 [[package]]
@@ -979,7 +979,7 @@ checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1023,7 +1023,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1099,9 +1099,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.77"
+version = "2.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
+checksum = "e02e925281e18ffd9d640e234264753c43edc62d64b2d4cf898f1bc5e75f3fc2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1174,7 +1174,7 @@ dependencies = [
  "signal-hook",
  "terminfo",
  "termios",
- "thiserror",
+ "thiserror 1.0.64",
  "ucd-trie",
  "unicode-segmentation",
  "vtparse",
@@ -1187,7 +1187,16 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d50af8abc119fb8bb6dbabcfa89656f46f84aa0ac7688088608076ad2b459a84"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.64",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+dependencies = [
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1198,7 +1207,18 @@ checksum = "08904e7672f5eb876eaaf87e0ce17857500934f4981c4a0ab2b4aa98baac7fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.99",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
 ]
 
 [[package]]
@@ -1508,5 +1528,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.77",
+ "syn 2.0.99",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,7 +134,7 @@ dependencies = [
  "deelevate",
  "dfu-core",
  "dfu-libusb",
- "env_logger",
+ "env_logger 0.11.6",
  "goblin",
  "indicatif",
  "lazy_static",
@@ -301,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "dfu-core"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1336c04109285c67da20d2cbb60ad732719ef71739a6e03a42b0afcd460376"
+checksum = "c5867e35cc12d5e5c775f16e10e5cd135f96756cc07bb4a715fb863f25001bbf"
 dependencies = [
  "bytes",
  "displaydoc",
@@ -314,12 +314,11 @@ dependencies = [
 
 [[package]]
 name = "dfu-libusb"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8e26483f014ff30c13993e61f13c6abf1ba02d61cd8d856612373150239817"
+checksum = "4664041609496e84cca3a0fcd48a4586b7029d93dbb4b89191854de5d1d47043"
 dependencies = [
  "dfu-core",
- "libusb1-sys",
  "rusb",
  "thiserror",
 ]
@@ -386,6 +385,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "env_filter"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "env_logger"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -396,6 +405,19 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -454,9 +476,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
-version = "0.8.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b363a30c165f666402fe6a3024d3bec7ebc898f96a4a23bd1c99f8dbf3f4f47"
+checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
 dependencies = [
  "log",
  "plain",
@@ -588,7 +610,7 @@ dependencies = [
  "bindgen",
  "cc",
  "diffy",
- "env_logger",
+ "env_logger 0.10.2",
  "log",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,21 +17,21 @@ vendored = ["rusb/vendored"]
 default = ["detect-backtrace", "vendored"]
 
 [dependencies]
-anstyle = "1.0.2"
+anstyle = "1.0"
 clap = { version = "4.0", default-features = false, features = ["std", "color", "help", "usage", "unicode", "wrap_help", "unstable-styles", "cargo"] }
-env_logger = "0.10"
-dfu-core = { version = "0.6.0", features = ["std"] }
-dfu-libusb = "0.5.1"
+env_logger = "0.11"
+dfu-core = { version = "0.7.0", features = ["std"] }
+dfu-libusb = "0.5.3"
 rusb = "0.9"
 log = "0.4"
 const_format = "0.2"
 anyhow = "1.0"
 thiserror = "1.0"
-indicatif = "0.17.5"
-termcolor = "1.2.0"
-goblin = { version = "0.8.0", default-features = false, features = ["std", "elf32", "elf64", "endian_fd"] }
-libc = "0.2.147"
-bstr = "1.6.0"
+indicatif = "0.17"
+termcolor = "1.4"
+goblin = { version = "0.9", default-features = false, features = ["std", "elf32", "elf64", "endian_fd"] }
+libc = "0.2"
+bstr = "1.10.0"
 
 [target.'cfg(windows)'.dependencies]
 wdi = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rusb = "0.9"
 log = "0.4"
 const_format = "0.2"
 anyhow = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 indicatif = "0.17"
 termcolor = "1.4"
 goblin = { version = "0.9", default-features = false, features = ["std", "elf32", "elf64", "endian_fd"] }


### PR DESCRIPTION
In this PR we update all the dependencies once more with the intention of solving the build problems v0.1.3 now has with the DFU crates due to improper versioning on those dependencies.

dfu-core released breaking changes in v0.7.0 and dfu-libusb released the matching patches in v0.5.3 as a revision release of v0.5.2. This, understandably, made cargo extremely grumpy when trying to solve the dependency changes per the pinning - using the newer dfu-libusb was allowed because it's a revision release, but the newer dfu-core was not because that's a minor and we pin down to the revision.

With both properly upgraded in sync, that solves the build problems.