### PR TITLE
Feature: Switch rusb to nusb

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
  "const_format",
  "deelevate",
  "dfu-core",
- "dfu-libusb",
+ "dfu-nusb",
  "dialoguer",
  "directories",
  "env_logger 0.11.8",
@@ -200,9 +200,9 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "nusb",
  "rc-zip-sync",
  "reqwest",
- "rusb",
  "rustc_version",
  "serde",
  "serde_json",
@@ -440,20 +440,21 @@ checksum = "c5867e35cc12d5e5c775f16e10e5cd135f96756cc07bb4a715fb863f25001bbf"
 dependencies = [
  "bytes",
  "displaydoc",
+ "futures",
  "log",
  "pretty-hex",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "dfu-libusb"
-version = "0.5.3"
+name = "dfu-nusb"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4664041609496e84cca3a0fcd48a4586b7029d93dbb4b89191854de5d1d47043"
+checksum = "f0b2472de95ea9a994cc90d8b5ccc62ded095714ffb16b2b3059cd805437b4c3"
 dependencies = [
  "dfu-core",
- "rusb",
- "thiserror 1.0.69",
+ "nusb",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -670,6 +671,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -686,10 +702,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "futures-sink"
@@ -709,8 +747,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1108,6 +1148,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,18 +1259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libusb1-sys"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da050ade7ac4ff1ba5379af847a10a10a8e284181e060105bf8d86960ce9ce0f"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "libwdi-sys"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1257,6 +1295,15 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "mach2"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memchr"
@@ -1404,6 +1451,25 @@ name = "number_prefix"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "nusb"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99a726776e551f3ee9b467fe47202f26e64b9bbf715df5443b0904df6f2dcc41"
+dependencies = [
+ "atomic-waker",
+ "core-foundation",
+ "core-foundation-sys",
+ "futures-core",
+ "io-kit-sys",
+ "libc",
+ "log",
+ "once_cell",
+ "rustix 0.38.44",
+ "slab",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "object"
@@ -1991,16 +2057,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rusb"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9f9ff05b63a786553a4c02943b74b34a988448671001e9a27e2f0565cc05a4"
-dependencies = [
- "libc",
- "libusb1-sys",
 ]
 
 [[package]]
@@ -3002,6 +3058,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3016,6 +3081,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3052,6 +3132,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3064,6 +3150,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3073,6 +3165,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3100,6 +3198,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3109,6 +3213,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3124,6 +3234,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3133,6 +3249,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,18 +7,13 @@ repository = "https://github.com/blackmagic-debug/bmputil"
 edition = "2024"
 default-run = "bmputil-cli"
 
-[features]
-# Automatically build libusb and statically link it instead of using system libusb.
-vendored = ["rusb/vendored"]
-default = ["vendored"]
-
 [dependencies]
 anstyle = "1.0"
 clap = { version = "4.0", default-features = false, features = ["std", "color", "help", "usage", "unicode", "wrap_help", "unstable-styles", "cargo"] }
 env_logger = "0.11"
 dfu-core = { version = "0.7.0", features = ["std"] }
-dfu-libusb = "0.5.3"
-rusb = "0.9"
+dfu-nusb = "0.1.1"
+nusb = "0.1"
 log = "0.4"
 const_format = "0.2"
 anyhow = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -7,26 +7,8 @@
 //! is detect if we are running nightly Rust, and enable backtrace support for errors
 //! if we are.
 
-use rustc_version::{version_meta, Channel};
-
 fn main()
 {
     // Statically link the Visual C runtime on Windows.
     static_vcruntime::metabuild();
-
-    // If detect-backtrace is enabled (default), detect if we're on nightly or not.
-    // If we're on nightly, enable backtraces automatically.
-    if let Some(_val) = std::env::var_os("CARGO_FEATURE_DETECT_BACKTRACE") {
-        match version_meta() {
-            Ok(version_meta) => {
-                if version_meta.channel == Channel::Nightly {
-                    // Tell Cargo to enable backtraces.
-                    println!("cargo:rustc-cfg=feature=\"backtrace\"");
-                }
-            },
-            Err(e) => {
-                println!("cargo:warning=error detecting rustc version: {}", e);
-            }
-        }
-    }
 }

--- a/build.rs
+++ b/build.rs
@@ -1,11 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: 2022-2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileCopyrightText: 2022-2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
-//! To whomever might be reading this, understandably skeptical of build scripts:
-//! This build script is *optional*, and exists only to set *default* options under
-//! circumstances under which they are supported. Actually, all this build script does
-//! is detect if we are running nightly Rust, and enable backtrace support for errors
-//! if we are.
+// SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 
 fn main()
 {

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -1,7 +1,9 @@
-use std::fmt::Debug;
 // SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: 2022-2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileCopyrightText: 2022-2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+// SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
+
+use std::fmt::Debug;
 use std::mem;
 use std::thread;
 use std::io::Read;

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -20,7 +20,6 @@ use nusb::descriptors::Descriptor;
 use dfu_nusb::{DfuNusb, Error as DfuNusbError};
 use dfu_core::{State as DfuState, Error as DfuCoreError};
 
-use crate::S;
 use crate::error::{Error, ErrorKind, ErrorSource, ResErrorKind};
 use crate::usb::{DfuFunctionalDescriptor, InterfaceClass, InterfaceSubClass, GenericDescriptorRef, DfuRequest};
 use crate::usb::{Vid, Pid, DfuOperatingMode};
@@ -203,7 +202,7 @@ impl BmpDevice
                 Duration::from_secs(2),
             )
             .map_err(
-                |e| ErrorKind::DeviceSeemsInvalid(S!("no product string descriptor")).error_from(e)
+                |e| ErrorKind::DeviceSeemsInvalid("no product string descriptor".into()).error_from(e)
             )
     }
 
@@ -285,8 +284,7 @@ impl BmpDevice
 
         let dfu_func_desc = DfuFunctionalDescriptor::copy_from_bytes(dfu_func_desc_bytes)
             .map_err(|source| {
-                ErrorKind::DeviceSeemsInvalid(String::from("DFU functional descriptor"))
-                    .error_from(source)
+                ErrorKind::DeviceSeemsInvalid("DFU functional descriptor".into()).error_from(source)
             })?;
 
         Ok((dfu_interface_descriptor.interface_number(), dfu_func_desc))
@@ -575,7 +573,7 @@ impl Display for BmpDevice
                 // from the write!() call below, not internal errors.
                 // https://doc.rust-lang.org/stable/std/fmt/index.html#formatting-traits.
                 error!("Error formatting BlackMagicProbeDevice: {}", e);
-                S!("Unknown Black Magic Probe (error occurred fetching device details)")
+                "Unknown Black Magic Probe (error occurred fetching device details)".into()
             }
         };
 
@@ -655,7 +653,10 @@ impl FirmwareType
 
         let vector_table = Armv7mVectorTable::from_bytes(buffer);
         let reset_vector = vector_table.reset_vector()
-            .map_err(|e| ErrorKind::InvalidFirmware(Some(S!("vector table too short"))).error_from(e))?;
+            .map_err(
+                |e| ErrorKind::InvalidFirmware(Some("vector table too short".into()))
+                    .error_from(e)
+            )?;
 
         debug!("Detected reset vector in firmware file: 0x{:08x}", reset_vector);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: 2022-2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileCopyrightText: 2022-2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+// SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 //! Module for error handling code.
 
 use std::{fmt::{Display, Formatter}, path::PathBuf};

--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -17,6 +17,7 @@ use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 use crate::bmp::{self, BmpDevice, FirmwareFormat, FirmwareType};
 use crate::elf;
 use crate::error::{Error, ErrorKind};
+use crate::usb::PortId;
 
 pub struct Firmware
 {
@@ -185,9 +186,9 @@ fn read_firmware(file_name: PathBuf) -> Result<Vec<u8>, Error>
     Ok(firmware_data)
 }
 
-fn check_programming(port: &str) -> Result<(), Error>
+fn check_programming(port: PortId) -> Result<(), Error>
 {
-    let dev = bmp::wait_for_probe_reboot(&port, Duration::from_secs(5), "flash")
+    let dev = bmp::wait_for_probe_reboot(port, Duration::from_secs(5), "flash")
         .map_err(|e| {
             error!("Black Magic Probe did not re-enumerate after flashing! Invalid firmware?");
             e
@@ -238,5 +239,5 @@ pub fn flash_probe(matches: &ArgMatches, mut device: BmpDevice, file_name: PathB
     drop(device);
     thread::sleep(Duration::from_millis(250));
 
-    check_programming(port.as_str())
+    check_programming(port)
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -240,6 +240,8 @@ pub struct PortId
     path: PathBuf,
     #[cfg(target_os = "windows")]
     port_number: u32,
+    #[cfg(target_os = "macos")]
+    location: u32,
 }
 
 impl PortId
@@ -252,6 +254,8 @@ impl PortId
             path: device.sysfs_path().to_path_buf(),
             #[cfg(target_os = "windows")]
             port_number: device.port_number(),
+            #[cfg(target_os = "macos")]
+            location: device.location_id(),
         }
     }
 }
@@ -270,6 +274,13 @@ impl PartialEq for PortId
     {
         return self.bus_number == other.bus_number &&
             self.port_number == other.port_number
+    }
+
+    #[cfg(target_os = "macos")]
+    fn eq(&self, other: &Self) -> bool
+    {
+        return self.bus_number == other.bus_number &&
+            self.location == other.location
     }
 }
 
@@ -294,5 +305,11 @@ impl Display for PortId
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result
     {
         write!(f, "{}-{}", self.bus_number, self.port_number)
+    }
+
+    #[cfg(target_os = "macos")]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result
+    {
+        write!(f, "{}-{}", self.bus_number, self.location)
     }
 }

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -225,26 +225,3 @@ impl DfuFunctionalDescriptor
         })
     }
 }
-
-/// The libusb version against which error conditions have been checked from its source code.
-pub(crate) const CHECKED_LIBUSB_VERSION: &str = "1.0.26";
-
-/// libusb has an API function whose documentation state non-zero return codes indicate failure
-/// (and thus the [`rusb`](https://docs.rs/rusb) equivalents for them return `Result<T>`),
-/// but the source code has no possible logic paths for a return code of anything other than zero,
-/// and the documentation states that currently no error is ever returned.
-/// Thus, `.unwrap()` panicking should be unreachable. This macro serves both as in-code
-/// documentation of these cases (as `.unwrap()`s tend to look sus), and as a fallback in case
-/// libusb updates or there is some failure condition that was missed in reviewing libusb's
-/// source code.
-#[macro_export]
-macro_rules! libusb_cannot_fail
-{
-    ($funcname:literal) => {
-        const_format::formatcp!(
-            "As of libusb {}, {} cannot fail. This should be unreachable, unless libusb has updated.",
-            $crate::usb::CHECKED_LIBUSB_VERSION,
-            $funcname,
-        )
-    };
-}

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: 2022-2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileCopyrightText: 2022-2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+// SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 
 use std::fmt::{self, Display};
 #[cfg(any(target_os = "linux", target_os = "android"))]


### PR DESCRIPTION
In this PR we move the tool from rusb and the underlying library libusb, which has been a good base but has problems which really need solving. As the all-Rust USB library, nusb became an obvious choice, so as dfu-nusb exists, we are moving the tool over to this.

This PR maintains full function of the tool on the big 3 OSes, however it is a rough and ready conversion and there are still quirks that need addressing - as outlined below:

![Flash cycle executed on Linux showing "Possibly spurious error from OS at the very end of flashing" due to a device disconnection](https://github.com/user-attachments/assets/fe529284-ffd8-4661-b39b-61f13eb4749e)
Linux needs the now consistent device disconnection catching and silencing from the end of the cycle as this is expected due to the device rebooting on conclusion of the cycle.

![Flash cycle executed on Windows showing a similar error, this time from endpoint STALL](https://github.com/user-attachments/assets/42e5a031-31a2-4d45-9263-7ddb96c9a939)
Windows also needs this same condition handling, only there it shows up as an endpoint STALL to be caught and burred. This is at least now consistent however, so we can do that.

![Flash cycle executed on macOS showing the third version of the error](https://github.com/user-attachments/assets/890af7a8-c230-4d66-a514-384c892e315d)
macOS finally needs a variation of this handled where an "unknown error" occurs which is the same thing near as we can tell, but is also consistent now so can be handled.

In the interests of change atomicity and moving forward, these things will be addressed in a follow-up PR. The newly introduced PortId type should likely be upstreamed to nusb as well so the community writ large can benefit from being able to track devices through reboots/reenumeration with it.