### PR TITLE
Feature: color-eyre error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -16,12 +16,6 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "adler2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
@@ -102,17 +96,17 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
+ "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.8.8",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -188,6 +182,7 @@ dependencies = [
  "anyhow",
  "bstr",
  "clap",
+ "color-eyre",
  "const_format",
  "deelevate",
  "dfu-core",
@@ -334,6 +329,33 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "color-eyre"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+dependencies = [
+ "backtrace",
+ "color-spantrace",
+ "eyre",
+ "indenter",
+ "once_cell",
+ "owo-colors",
+ "tracing-error",
+]
+
+[[package]]
+name = "color-spantrace"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+dependencies = [
+ "once_cell",
+ "owo-colors",
+ "tracing-core",
+ "tracing-error",
+]
 
 [[package]]
 name = "colorchoice"
@@ -624,6 +646,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "eyre"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
+dependencies = [
+ "indenter",
+ "once_cell",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -798,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "glob"
@@ -1125,6 +1157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "indenter"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+
+[[package]]
 name = "indexmap"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,15 +1377,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
-dependencies = [
- "adler2",
-]
-
-[[package]]
 name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1473,9 +1502,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
@@ -1595,6 +1624,12 @@ dependencies = [
  "quote",
  "syn 2.0.100",
 ]
+
+[[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
 name = "pathsearch"
@@ -1922,7 +1957,7 @@ dependencies = [
  "chrono",
  "crc32fast",
  "encoding_rs",
- "miniz_oxide 0.7.4",
+ "miniz_oxide",
  "num_enum",
  "oem_cp",
  "oval",
@@ -2312,6 +2347,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shared_library"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2591,6 +2635,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2736,6 +2790,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-error"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1581020d7a273442f5b45074a6a57d5757ad0a47dac0e9f0bd57b81936f3db"
+dependencies = [
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
 ]
 
 [[package]]
@@ -2821,6 +2897,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ rc-zip-sync = "4.2.6"
 dialoguer = "0.11.0"
 directories = "6.0.0"
 sha2 = "0.10.8"
+color-eyre = "0.6.3"
 
 [target.'cfg(windows)'.dependencies]
 wdi = "0.1.0"

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -8,7 +8,7 @@ use std::str::FromStr;
 use anstyle;
 use clap::{ArgAction, Command, Arg, ArgMatches, crate_version, crate_description, crate_name};
 use clap::builder::styling::Styles;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Context, Result};
 use directories::ProjectDirs;
 use log::{info, error};
 
@@ -29,10 +29,7 @@ fn detach_command(matches: &ArgMatches) -> Result<()>
         FirmwareUpgrade => println!("Requesting device detach from DFU mode to runtime mode..."),
     };
 
-    dev.detach_and_destroy()
-        .map_err(|e| e.with_ctx("detaching device"))?;
-
-    Ok(())
+    dev.detach_and_destroy().wrap_err("detaching device")
 }
 
 fn flash(matches: &ArgMatches) -> Result<()>

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -46,7 +46,7 @@ fn flash(matches: &ArgMatches) -> Result<()>
     // TODO: flashing to multiple BMPs at once should be supported, but maybe we should require some kind of flag?
     let dev: BmpDevice = results.pop_single("flash")?;
 
-    Ok(bmputil::flasher::flash_probe(matches, dev, file_name.into())?)
+    bmputil::flasher::flash_probe(matches, dev, file_name.into())
 }
 
 fn display_releases(paths: &ProjectDirs) -> Result<()>

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -321,7 +321,7 @@ fn main() -> Result<()>
             other => unreachable!("Unhandled subcommand {:?}", other),
         },
         "releases" => display_releases(&paths),
-        "switch" => Ok(bmputil::switcher::switch_firmware(subcommand_matches, &paths)?),
+        "switch" => bmputil::switcher::switch_firmware(subcommand_matches, &paths),
         &_ => unimplemented!(),
     }
 }

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -413,10 +413,7 @@ impl BmpDevice
     {
         match dfu_iface.download(firmware, length) {
             Ok(_) => if dfu_iface.will_detach() {
-            match dfu_iface.detach() {
-                    Err(source) => Err(ErrorKind::DeviceReboot.error_from(source).into()),
-                    _ => Ok(()),
-                }
+                Ok(dfu_iface.detach()?)
             } else {
                 Ok(())
             },

--- a/src/elf.rs
+++ b/src/elf.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: 2022-2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileCopyrightText: 2022-2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+// SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
+
+use color_eyre::eyre::Result;
 use goblin::elf::{Elf, SectionHeader};
 use goblin::error::Error as GoblinError;
-
-use crate::S;
 
 /// Convenience extensions to [Elf].
 trait ElfExt
@@ -34,12 +35,12 @@ impl<'a> ElfExt for Elf<'a>
 trait SectionHeaderExt
 {
     /// Get the raw data of this section, given the full ELF data.
-    fn get_data<'s>(&'s self, parent_data: &'s [u8]) -> Result<&'s [u8], GoblinError>;
+    fn get_data<'s>(&'s self, parent_data: &'s [u8]) -> Result<&'s [u8]>;
 }
 
 impl SectionHeaderExt for SectionHeader
 {
-    fn get_data<'s>(&'s self, parent_data: &'s [u8]) -> Result<&'s [u8], GoblinError>
+    fn get_data<'s>(&'s self, parent_data: &'s [u8]) -> Result<&'s [u8]>
     {
         let start_idx = self.sh_offset as usize;
         let size = self.sh_size;
@@ -61,7 +62,7 @@ impl SectionHeaderExt for SectionHeader
 /// This should be equivalent to `$ arm-none-eabi-objcopy -Obinary`, but is not yet robust
 /// enough to automatically detect what sections should be copied.
 /// Currently, `.text`, `.ARM.exidx`, and `.data` are copied.
-pub fn extract_binary(elf_data: &[u8]) -> Result<Vec<u8>, goblin::error::Error>
+pub fn extract_binary(elf_data: &[u8]) -> Result<Vec<u8>>
 {
     let elf = Elf::parse(elf_data)?;
 
@@ -71,7 +72,7 @@ pub fn extract_binary(elf_data: &[u8]) -> Result<Vec<u8>, goblin::error::Error>
 
     let text = elf
         .get_section_by_name(".text")
-        .ok_or_else(|| GoblinError::Malformed(S!("ELF .text section not found")))?
+        .ok_or_else(|| GoblinError::Malformed("ELF .text section not found".into()))?
         .get_data(elf_data)?;
 
     // Allow .ARM.exidx to not exist.
@@ -83,7 +84,7 @@ pub fn extract_binary(elf_data: &[u8]) -> Result<Vec<u8>, goblin::error::Error>
 
     let data = elf
         .get_section_by_name(".data")
-        .ok_or_else(|| GoblinError::Malformed(S!("ELF .data section not found")))?
+        .ok_or_else(|| GoblinError::Malformed("ELF .data section not found".into()))?
         .get_data(elf_data)?;
 
 

--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -139,6 +139,8 @@ impl Firmware
                             // bootloader rebooting and we can safely ignore it
                             #[cfg(target_os = "windows")]
                             TransferError::Stall => Ok(()),
+                            #[cfg(target_os = "macos")]
+                            TransferError::Unknown => Ok(()),
                             _ => {
                                 warn!("Possibly spurious error from OS at the very end of flashing: {}", err);
                                 Err(err.into())

--- a/src/metadata/mod.rs
+++ b/src/metadata/mod.rs
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Writen by Rachel Mant <git@dragonmux.network>
+
 pub mod structs;
 
 use std::fs::{create_dir_all, File};

--- a/src/metadata/structs.rs
+++ b/src/metadata/structs.rs
@@ -1,3 +1,7 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Writen by Rachel Mant <git@dragonmux.network>
+
 use std::{collections::BTreeMap, path::PathBuf};
 use std::str::FromStr;
 use std::string::ToString;

--- a/src/metadata/structs.rs
+++ b/src/metadata/structs.rs
@@ -2,11 +2,10 @@ use std::{collections::BTreeMap, path::PathBuf};
 use std::str::FromStr;
 use std::string::ToString;
 
+use color_eyre::eyre::{eyre, Error, Result};
 use reqwest::Url;
 use serde::Deserialize;
 use serde::de::Visitor;
-
-use crate::error::{Error, ErrorKind};
 
 #[derive(Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -134,7 +133,7 @@ impl FromStr for Probe
 			"stlink" => Ok(Probe::Stlink),
 			"stlinkv3" => Ok(Probe::Stlinkv3),
 			"swlink" => Ok(Probe::Swlink),
-			&_ => Err(Error::new(ErrorKind::ReleaseMetadataInvalid, None))
+			&_ => Err(eyre!("Failed to translate invalid probe name {value} to Probe enum"))
 		}
 	}
 }
@@ -203,7 +202,7 @@ impl FromStr for TargetOS
 			"linux" => Ok(TargetOS::Linux),
 			"macos" => Ok(TargetOS::MacOS),
 			"windows" => Ok(TargetOS::Windows),
-			&_ => Err(Error::new(ErrorKind::ReleaseMetadataInvalid, None))
+			&_ => Err(eyre!("Failed to translate invalid operating system name {value} to TargetOS enum"))
 		}
 	}
 }
@@ -261,7 +260,7 @@ impl FromStr for TargetArch
 			"amd64" => Ok(TargetArch::AMD64),
 			"aarch32" => Ok(TargetArch::AArch32),
 			"aarch64" => Ok(TargetArch::AArch64),
-			&_ => Err(Error::new(ErrorKind::ReleaseMetadataInvalid, None))
+			&_ => Err(eyre!("Failed to translate invalid architecture name {value} to TargetArch enum"))
 		}
 	}
 }

--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -78,7 +78,7 @@ pub fn switch_firmware(matches: &ArgMatches, paths: &ProjectDirs) -> Result<()>
     let elf_file = download_firmware(firmware_variant, cache)?;
 
     // Having done all of that, finally try to Flash the new firmware on the probe
-    Ok(flasher::flash_probe(matches, probe, elf_file)?)
+    flasher::flash_probe(matches, probe, elf_file)
 }
 
 fn select_probe(matches: &ArgMatches) -> Result<Option<BmpDevice>>

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -7,6 +7,7 @@ use std::fmt::{self, Display};
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::path::PathBuf;
 
+use color_eyre::eyre::Result;
 use nusb::DeviceInfo;
 use thiserror::Error;
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
-// SPDX-FileCopyrightText: 2022-2023 1BitSquared <info@1bitsquared.com>
+// SPDX-FileCopyrightText: 2022-2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+// SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 //! This module handles Windows-specific code, mostly the installation of drivers for Black Magic Probe USB interfaces.
 //!
 //! "Installation" is a somewhat overloaded term, in Windows. Behind the scenes this module, using
@@ -33,10 +34,11 @@ use std::iter;
 use std::thread;
 use std::str::FromStr;
 use std::time::Duration;
-use std::io::{Error as IoError, Result as IoResult};
+use std::io::Error as IoError;
 use std::ffi::{OsStr, OsString, CString};
 use std::os::windows::ffi::OsStrExt;
 
+use color_eyre::eyre::Result;
 use libc::{intptr_t, c_int, c_uint, c_long, c_char, FILE};
 use log::{trace, debug, info, warn, error};
 use bstr::ByteSlice;
@@ -172,7 +174,7 @@ pub struct UcrtStdioStreamData
 /// C's printf() on the other hand goes through whatever file descriptor the `stdout` global is set to,
 /// and that is *not* updated when you call AttachConsole(). So, we need to resynchronize the
 /// Microsoft C Runtime's stdio global state with the Windows console subsystem state.
-pub fn restore_cstdio(parent_pid: u32) -> Result<(), IoError>
+pub fn restore_cstdio(parent_pid: u32) -> Result<()>
 {
 
     // First, free whatever console Windows gave us by default, and attach to the parent's console.
@@ -306,7 +308,7 @@ lazy_static! {
 ///
 /// [enumerator]: (https://learn.microsoft.com/en-us/windows/win32/api/setupapi/nf-setupapi-setupdigetclassdevsw)
 /// [HardwareId]: (https://learn.microsoft.com/en-us/windows-hardware/drivers/install/hardware-ids)
-pub fn hwid_bound_to_driver(hardware_id: &str, enumerator: &str) -> IoResult<Vec<String>>
+pub fn hwid_bound_to_driver(hardware_id: &str, enumerator: &str) -> Result<Vec<String>>
 {
     debug!("Checking what drivers device {} under enumerator {} is bound to", hardware_id, enumerator);
 


### PR DESCRIPTION
In this PR we replace most of the error handling mechanisms in the utility with color-eyre's error handling type - this nets us a large improvement in error output and makes diving the cause of an error differently interesting.

Generally, though, this seems to be a net win as we get the standard downcast<>() call for converting error types to more specific ones in error mapping situations, and the possibility of arbitrary appropriate error texts generated where the errors occur while dealing with external error types transparently and providing line number information for where things went wrong in a nice friendly error display block.

This PR also rearranges a portion of the download and reboot logic for a probe to suppress spurious post-download errors effectively.