### PR TITLE
Fix: Improved download UX

### DIFF
--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -128,6 +128,7 @@ fn style() -> clap::builder::Styles {
 
 fn main() -> Result<()>
 {
+    color_eyre::install()?;
     env_logger::Builder::new()
         .filter_level(log::LevelFilter::Warn)
         .parse_default_env()

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -21,7 +21,9 @@ fn detach_command(matches: &ArgMatches) -> Result<()>
 {
     let matcher = BmpMatcher::from_cli_args(matches);
     let mut results = matcher.find_matching_probes();
-    let dev = results.pop_single("detach")?;
+    let dev = results
+        .pop_single("detach")
+        .map_err(|kind| kind.error())?;
 
     use bmputil::usb::DfuOperatingMode::*;
     match dev.operating_mode() {
@@ -41,7 +43,9 @@ fn flash(matches: &ArgMatches) -> Result<()>
     let matcher = BmpMatcher::from_cli_args(matches);
     let mut results = matcher.find_matching_probes();
     // TODO: flashing to multiple BMPs at once should be supported, but maybe we should require some kind of flag?
-    let dev: BmpDevice = results.pop_single("flash")?;
+    let dev: BmpDevice = results
+        .pop_single("flash")
+        .map_err(|kind| kind.error())?;
 
     bmputil::flasher::flash_probe(matches, dev, file_name.into())
 }

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -991,7 +991,7 @@ pub fn wait_for_probe_reboot(port: PortId, timeout: Duration, operation: &str) -
 
     let mut dev = matcher.find_matching_probes().pop_single_silent();
 
-    while let Err(ErrorKind::DeviceNotFound) = dev.err_kind() {
+    while let Some(ErrorKind::DeviceNotFound) = dev.err_kind() {
 
         trace!("Waiting for probe reboot: {} ms", Instant::now().duration_since(start).as_millis());
 

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -13,10 +13,7 @@ use std::fmt::{self, Display, Formatter};
 use std::array::TryFromSliceError;
 
 use clap::ArgMatches;
-use color_eyre::eyre::eyre;
-use color_eyre::eyre::Context;
-use color_eyre::eyre::Report;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{eyre, Context, Error, Report, Result};
 use dfu_core::DfuIo;
 use dfu_core::DfuProtocol;
 use dfu_nusb::DfuSync;
@@ -1000,7 +997,12 @@ pub fn wait_for_probe_reboot(port: PortId, timeout: Duration, operation: &str) -
             error!(
                 "Timed-out waiting for Black Magic Probe to re-enumerate!"
             );
-            return Err(ErrorKind::DeviceReboot.error_from(dev.unwrap_err().error()).into());
+            return dev
+                .map_err(
+                    |kind|
+                    Error::from(kind.error())
+                        .wrap_err("Black Magic Probe device did not come back online (invalid firmware?)")
+                )
         }
 
         // Wait 200 milliseconds between checks. Hardware is a bottleneck and we

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -26,7 +26,7 @@ use nusb::descriptors::Descriptor;
 use dfu_nusb::{DfuNusb, Error as DfuNusbError};
 use dfu_core::{State as DfuState, Error as DfuCoreError};
 
-use crate::error::{Error, ErrorKind};
+use crate::error::ErrorKind;
 use crate::usb::{DfuFunctionalDescriptor, InterfaceClass, InterfaceSubClass, GenericDescriptorRef, DfuRequest, PortId};
 use crate::usb::{Vid, Pid, DfuOperatingMode};
 
@@ -425,7 +425,7 @@ impl BmpDevice
             .download(firmware, length)
             .map_err(|source|
                 match source {
-                    dfu_nusb::Error::Transfer(nusb::transfer::TransferError::Disconnected) => {
+                    DfuNusbError::Transfer(nusb::transfer::TransferError::Disconnected) => {
                         error!("Black Magic Probe device disconnected during the flash process!");
                         warn!(
                             "If the device now fails to enumerate, try holding down the button while plugging the device in order to enter the bootloader."
@@ -873,7 +873,7 @@ pub struct BmpMatchResults
 impl BmpMatchResults
 {
     /// Pops all found devices, handling printing error and warning cases.
-    pub fn pop_all(&mut self) -> Result<Vec<BmpDevice>, Error>
+    pub fn pop_all(&mut self) -> Result<Vec<BmpDevice>>
     {
         if self.found.is_empty() {
 
@@ -901,7 +901,7 @@ impl BmpMatchResults
                 warn!("Device not found and errors occurred when searching for devices.");
                 warn!("One of these may be why the Black Magic Probe device was not found: {:?}", self.errors.as_slice());
             }
-            return Err(ErrorKind::DeviceNotFound.error());
+            return Err(ErrorKind::DeviceNotFound.error().into());
         }
 
         if !self.errors.is_empty() {

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -976,7 +976,7 @@ impl BmpMatchResults
 /// versions, and thus also between application and bootloader mode, so serial number is not a
 /// reliable way to keep track of a single device across USB resets.
 // TODO: test how reliable the port path is on multiple platforms.
-pub fn wait_for_probe_reboot(port: PortId, timeout: Duration, operation: &str) -> Result<BmpDevice, Error>
+pub fn wait_for_probe_reboot(port: PortId, timeout: Duration, operation: &str) -> Result<BmpDevice>
 {
     let silence_timeout = timeout / 2;
 
@@ -999,7 +999,7 @@ pub fn wait_for_probe_reboot(port: PortId, timeout: Duration, operation: &str) -
             error!(
                 "Timed-out waiting for Black Magic Probe to re-enumerate!"
             );
-            return Err(ErrorKind::DeviceReboot.error_from(dev.unwrap_err().error()));
+            return Err(ErrorKind::DeviceReboot.error_from(dev.unwrap_err().error()).into());
         }
 
         // Wait 200 milliseconds between checks. Hardware is a bottleneck and we

--- a/src/error.rs
+++ b/src/error.rs
@@ -269,21 +269,3 @@ pub enum ErrorSource
     #[error(transparent)]
     DfuCore(#[from] dfu_core::Error),
 }
-
-/// Extension trait to enable getting the error kind from a Result<T, Error> with one method.
-pub trait ResErrorKind
-{
-    type Kind;
-
-    fn err_kind(&self) -> Option<&Self::Kind>;
-}
-
-impl<T> ResErrorKind for Result<T, Error>
-{
-    type Kind = ErrorKind;
-
-    fn err_kind(&self) -> Option<&Self::Kind>
-    {
-        self.as_ref().err().map(|error| &error.kind)
-    }
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -156,7 +156,6 @@ impl Error
         }
     }
 
-    #[allow(dead_code)]
     /// Add additional context about what was being attempted when this error occurred.
     ///
     /// Example: "reading current firmware version".
@@ -166,7 +165,6 @@ impl Error
         self
     }
 
-    #[allow(dead_code)]
     /// Removes previously added context.
     pub fn without_ctx(mut self) -> Self
     {
@@ -273,18 +271,19 @@ pub enum ErrorSource
 }
 
 /// Extension trait to enable getting the error kind from a Result<T, Error> with one method.
-pub trait ResErrorKind<T>
+pub trait ResErrorKind
 {
     type Kind;
-    fn err_kind(&self) -> Result<&T, &Self::Kind>;
+
+    fn err_kind(&self) -> Option<&Self::Kind>;
 }
 
-impl<T> ResErrorKind<T> for Result<T, Error>
+impl<T> ResErrorKind for Result<T, Error>
 {
     type Kind = ErrorKind;
 
-    fn err_kind(&self) -> Result<&T, &Self::Kind>
+    fn err_kind(&self) -> Option<&Self::Kind>
     {
-        self.as_ref().map_err(|e| &e.kind)
+        self.as_ref().err().map(|error| &error.kind)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,10 +27,6 @@ pub enum ErrorKind
     /// Black Magic Probe found disconnected during an ongoing operation.
     DeviceDisconnectDuringOperation,
 
-    /// Black Magic Probe device did not come back online (e.g. after switching to DFU mode
-    /// or flashing firmware).
-    DeviceReboot,
-
     /// Black Magic Probe device returned bad data during configuration.
     ///
     /// This generally shouldn't be possible, but could happen if the cable is bad, the OS is
@@ -91,7 +87,6 @@ impl Display for ErrorKind
             TooManyDevices => write!(f, "current operation only supports one Black Magic Probe device but more than one device was found")?,
             DeviceNotFound => write!(f, "Black Magic Probe device not found (check connection?)")?,
             DeviceDisconnectDuringOperation => write!(f, "Black Magic Probe device found disconnected")?,
-            DeviceReboot => write!(f, "Black Magic Probe device did not come back online (invalid firmware?)")?,
             DeviceSeemsInvalid(thing) => {
                 write!(
                     f,

--- a/src/error.rs
+++ b/src/error.rs
@@ -121,9 +121,6 @@ impl Display for ErrorKind
             External(source) => {
                 use ErrorSource::*;
                 match source {
-                    StdIo(e) => {
-                        write!(f, "unhandled std::io::Error: {}", e)?;
-                    },
                     Nusb(e) => {
                         write!(f, "unhandled nusb error: {}", e.0)?;
                     },
@@ -211,15 +208,6 @@ impl StdError for Error
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)>
     {
         self.source.as_deref().map(|e| e as &dyn StdError)
-    }
-}
-
-impl From<std::io::Error> for Error
-{
-    fn from(other: std::io::Error) -> Self
-    {
-        use ErrorKind::*;
-        ReleaseMetadataInvalid.error_from(External(ErrorSource::StdIo(other)).error())
     }
 }
 
@@ -316,9 +304,6 @@ impl From<dfu_core::Error> for Error
 #[derive(Debug, Error)]
 pub enum ErrorSource
 {
-    #[error(transparent)]
-    StdIo(#[from] std::io::Error),
-
     #[error(transparent)]
     Nusb(#[from] NusbError),
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,8 +9,6 @@ use std::error::Error as StdError;
 
 use thiserror::Error;
 
-use crate::S;
-
 /// More convenient alias for `Box<dyn StdError + Send + Sync>`,
 /// which shows up in a few signatures and structs.
 type BoxedError = Box<dyn StdError + Send + Sync>;
@@ -214,15 +212,15 @@ impl From<dfu_nusb::Error> for Error
                 External(ErrorSource::Nusb(source)).error()
             },
             Source::AltSettingNotFound => {
-                DeviceSeemsInvalid(S!("DFU interface (alt mode) not found"))
+                DeviceSeemsInvalid("DFU interface (alt mode) not found".into())
                     .error_from(other)
             },
             Source::FunctionalDescriptorNotFound => {
-                DeviceSeemsInvalid(S!("DFU functional descriptor not found"))
+                DeviceSeemsInvalid("DFU functional descriptor not found".into())
                     .error_from(other)
             },
             Source::FunctionalDescriptor(source) => {
-                DeviceSeemsInvalid(S!("DFU functional interface descriptor"))
+                DeviceSeemsInvalid("DFU functional interface descriptor".into())
                     .error_from(source)
             },
             anything_else => {
@@ -245,11 +243,11 @@ impl From<dfu_core::Error> for Error
                     .error_from(source)
             },
             Source::InvalidAddress => {
-                DeviceSeemsInvalid(S!("DFU interface memory layout string"))
+                DeviceSeemsInvalid("DFU interface memory layout string".into())
                     .error_from(other)
             },
             Source::InvalidInterfaceString => {
-                DeviceSeemsInvalid(S!("DFU interface memory layout string"))
+                DeviceSeemsInvalid("DFU interface memory layout string".into())
                     .error_from(other)
             },
             anything_else => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -142,9 +142,6 @@ impl Display for ErrorKind
                     SerdeJSON(e) => {
                         write!(f, "unhandled serde JSON parsing error: {}", e)?;
                     }
-                    Dialoguer(e) => {
-                        write!(f, "unhandled dialoguer error: {}", e)?;
-                    }
                 };
             },
         };
@@ -340,15 +337,6 @@ impl From<serde_json::Error> for Error
     }
 }
 
-impl From<dialoguer::Error> for Error
-{
-    fn from(other: dialoguer::Error) -> Self
-    {
-        use ErrorKind::*;
-        External(ErrorSource::Dialoguer(other)).error()
-    }
-}
-
 /// Sources of external error in this library.
 #[derive(Debug, Error)]
 pub enum ErrorSource
@@ -373,9 +361,6 @@ pub enum ErrorSource
 
     #[error(transparent)]
     SerdeJSON(#[from] serde_json::Error),
-
-    #[error(transparent)]
-    Dialoguer(#[from] dialoguer::Error),
 }
 
 /// Extension trait to enable getting the error kind from a Result<T, Error> with one method.

--- a/src/error.rs
+++ b/src/error.rs
@@ -217,15 +217,6 @@ impl From<NusbError> for Error
     }
 }
 
-impl From<nusb::descriptors::ActiveConfigurationError> for Error
-{
-    fn from(other: nusb::descriptors::ActiveConfigurationError) -> Self
-    {
-        use ErrorKind::*;
-        DeviceSeemsInvalid("could not read active configuration for device".into()).error_from(other)
-    }
-}
-
 impl From<dfu_nusb::Error> for Error
 {
     fn from(other: dfu_nusb::Error) -> Self

--- a/src/error.rs
+++ b/src/error.rs
@@ -290,14 +290,3 @@ impl<T> ResErrorKind<T> for Result<T, Error>
         self.as_ref().map_err(|e| &e.kind)
     }
 }
-
-
-#[macro_export]
-macro_rules! log_and_return
-{
-    ($err:expr) => {
-        let err = $err;
-        log::error!("{}", err);
-        return Err(err);
-    }
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -145,9 +145,6 @@ impl Display for ErrorKind
                     Dialoguer(e) => {
                         write!(f, "unhandled dialoguer error: {}", e)?;
                     }
-                    Reqwest(e) => {
-                        write!(f, "unhandled reqwest error: {}", e)?;
-                    }
                 };
             },
         };
@@ -352,15 +349,6 @@ impl From<dialoguer::Error> for Error
     }
 }
 
-impl From<reqwest::Error> for Error
-{
-    fn from(other: reqwest::Error) -> Self
-    {
-        use ErrorKind::*;
-        External(ErrorSource::Reqwest(other)).error()
-    }
-}
-
 /// Sources of external error in this library.
 #[derive(Debug, Error)]
 pub enum ErrorSource
@@ -388,9 +376,6 @@ pub enum ErrorSource
 
     #[error(transparent)]
     Dialoguer(#[from] dialoguer::Error),
-
-    #[error(transparent)]
-    Reqwest(#[from] reqwest::Error),
 }
 
 /// Extension trait to enable getting the error kind from a Result<T, Error> with one method.

--- a/src/error.rs
+++ b/src/error.rs
@@ -208,15 +208,6 @@ impl StdError for Error
     }
 }
 
-impl From<NusbError> for Error
-{
-    fn from(other: NusbError) -> Self
-    {
-        use ErrorKind::*;
-        External(ErrorSource::Nusb(other)).error()
-    }
-}
-
 impl From<dfu_nusb::Error> for Error
 {
     fn from(other: dfu_nusb::Error) -> Self

--- a/src/error.rs
+++ b/src/error.rs
@@ -124,9 +124,6 @@ impl Display for ErrorKind
                     Nusb(e) => {
                         write!(f, "unhandled nusb error: {}", e.0)?;
                     },
-                    NusbTransfer(e) => {
-                        write!(f, "unhandled nusb transfer error: {}", e)?;
-                    }
                     DfuNusb(e) => {
                         write!(f, "unhandled dfu_nusb error: {}", e)?;
                     },
@@ -220,20 +217,6 @@ impl From<NusbError> for Error
     }
 }
 
-impl From<nusb::transfer::TransferError> for Error
-{
-    fn from(other: nusb::transfer::TransferError) -> Self
-    {
-        use ErrorKind::*;
-        use nusb::transfer::TransferError;
-
-        match other {
-            TransferError::Disconnected => DeviceDisconnectDuringOperation.error_from(other),
-            other => External(ErrorSource::NusbTransfer(other)).error(),
-        }
-    }
-}
-
 impl From<nusb::descriptors::ActiveConfigurationError> for Error
 {
     fn from(other: nusb::descriptors::ActiveConfigurationError) -> Self
@@ -306,9 +289,6 @@ pub enum ErrorSource
 {
     #[error(transparent)]
     Nusb(#[from] NusbError),
-
-    #[error(transparent)]
-    NusbTransfer(#[from] nusb::transfer::TransferError),
 
     #[error(transparent)]
     DfuNusb(#[from] dfu_nusb::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -15,11 +15,6 @@ use crate::S;
 /// which shows up in a few signatures and structs.
 type BoxedError = Box<dyn StdError + Send + Sync>;
 
-/// A unique type to hold Nusb error state
-#[derive(Debug, Error)]
-#[error(transparent)]
-pub struct NusbError(#[from] nusb::Error);
-
 /// Kinds of errors for [Error]. Use [ErrorKind::error] and [ErrorKind::error_from] to generate the
 /// [Error] value for this ErrorKind.
 #[derive(Debug)]
@@ -122,7 +117,7 @@ impl Display for ErrorKind
                 use ErrorSource::*;
                 match source {
                     Nusb(e) => {
-                        write!(f, "unhandled nusb error: {}", e.0)?;
+                        write!(f, "unhandled nusb error: {}", e)?;
                     },
                     DfuNusb(e) => {
                         write!(f, "unhandled dfu_nusb error: {}", e)?;
@@ -216,7 +211,7 @@ impl From<dfu_nusb::Error> for Error
         use dfu_nusb::Error as Source;
         match other {
             Source::Nusb(source) => {
-                External(ErrorSource::Nusb(NusbError(source))).error()
+                External(ErrorSource::Nusb(source)).error()
             },
             Source::AltSettingNotFound => {
                 DeviceSeemsInvalid(S!("DFU interface (alt mode) not found"))
@@ -270,7 +265,7 @@ impl From<dfu_core::Error> for Error
 pub enum ErrorSource
 {
     #[error(transparent)]
-    Nusb(#[from] NusbError),
+    Nusb(#[from] nusb::Error),
 
     #[error(transparent)]
     DfuNusb(#[from] dfu_nusb::Error),

--- a/src/error.rs
+++ b/src/error.rs
@@ -136,9 +136,6 @@ impl Display for ErrorKind
                     DfuCore(e) => {
                         write!(f, "unhandled dfu_core error: {}", e)?;
                     },
-                    Goblin(e) => {
-                        write!(f, "unhandled ELF parsing error: {}", e)?;
-                    },
                 };
             },
         };
@@ -315,16 +312,6 @@ impl From<dfu_core::Error> for Error
     }
 }
 
-impl From<goblin::error::Error> for Error
-{
-    fn from(other: goblin::error::Error) -> Self
-    {
-        use ErrorKind::*;
-        InvalidFirmware(None)
-            .error_from(External(ErrorSource::Goblin(other)).error())
-    }
-}
-
 /// Sources of external error in this library.
 #[derive(Debug, Error)]
 pub enum ErrorSource
@@ -343,9 +330,6 @@ pub enum ErrorSource
 
     #[error(transparent)]
     DfuCore(#[from] dfu_core::Error),
-
-    #[error(transparent)]
-    Goblin(#[from] goblin::error::Error),
 }
 
 /// Extension trait to enable getting the error kind from a Result<T, Error> with one method.

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,7 +4,7 @@
 // SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 //! Module for error handling code.
 
-use std::{fmt::{Display, Formatter}, path::PathBuf};
+use std::fmt::{Display, Formatter};
 use std::error::Error as StdError;
 
 use thiserror::Error;
@@ -18,12 +18,6 @@ type BoxedError = Box<dyn StdError + Send + Sync>;
 #[derive(Debug)]
 pub enum ErrorKind
 {
-    /// Failed to read firmware file.
-    FirmwareFileIo(/** filename **/ Option<PathBuf>),
-
-    /// Specified firmware seems invalid.
-    InvalidFirmware(/** why **/ Option<String>),
-
     /// Current operation only supports one Black Magic Probe but more tha none device was found.
     TooManyDevices,
 
@@ -94,8 +88,6 @@ impl Display for ErrorKind
     {
         use ErrorKind::*;
         match self {
-            FirmwareFileIo(None) => write!(f, "failed to read firmware file")?,
-            FirmwareFileIo(Some(filename)) => write!(f, "failed to read firmware file {}", filename.to_string_lossy())?,
             TooManyDevices => write!(f, "current operation only supports one Black Magic Probe device but more than one device was found")?,
             DeviceNotFound => write!(f, "Black Magic Probe device not found (check connection?)")?,
             DeviceDisconnectDuringOperation => write!(f, "Black Magic Probe device found disconnected")?,
@@ -108,8 +100,6 @@ impl Display for ErrorKind
                     thing,
                 )?;
             },
-            InvalidFirmware(None) => write!(f, "specified firmware does not seem valid")?,
-            InvalidFirmware(Some(why)) => write!(f, "specified firmware does not seem valid: {}", why)?,
             ReleaseMetadataInvalid => write!(f, "Black Magic Debug release metadata was mallformed")?,
             External(source) => {
                 use ErrorSource::*;
@@ -154,22 +144,6 @@ impl Error
             source,
             context: None
         }
-    }
-
-    /// Add additional context about what was being attempted when this error occurred.
-    ///
-    /// Example: "reading current firmware version".
-    pub fn with_ctx(mut self, ctx: &str) -> Self
-    {
-        self.context = Some(ctx.to_string());
-        self
-    }
-
-    /// Removes previously added context.
-    pub fn without_ctx(mut self) -> Self
-    {
-        self.context = None;
-        self
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -139,9 +139,6 @@ impl Display for ErrorKind
                     Goblin(e) => {
                         write!(f, "unhandled ELF parsing error: {}", e)?;
                     },
-                    SerdeJSON(e) => {
-                        write!(f, "unhandled serde JSON parsing error: {}", e)?;
-                    }
                 };
             },
         };
@@ -328,15 +325,6 @@ impl From<goblin::error::Error> for Error
     }
 }
 
-impl From<serde_json::Error> for Error
-{
-    fn from(other: serde_json::Error) -> Self
-    {
-        use ErrorKind::*;
-        ReleaseMetadataInvalid.error_from(External(ErrorSource::SerdeJSON(other)).error())
-    }
-}
-
 /// Sources of external error in this library.
 #[derive(Debug, Error)]
 pub enum ErrorSource
@@ -358,9 +346,6 @@ pub enum ErrorSource
 
     #[error(transparent)]
     Goblin(#[from] goblin::error::Error),
-
-    #[error(transparent)]
-    SerdeJSON(#[from] serde_json::Error),
 }
 
 /// Extension trait to enable getting the error kind from a Result<T, Error> with one method.

--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -137,7 +137,7 @@ impl Firmware
                             TransferError::Disconnected => Ok(()),
                             // If the error reported on Windows was a STALL, that was just the
                             // bootloader rebooting and we can safely ignore it
-                            #[cfg(target_os = "windows")]
+                            #[cfg(any(target_os = "windows", target_os = "macos"))]
                             TransferError::Stall => Ok(()),
                             #[cfg(target_os = "macos")]
                             TransferError::Unknown => Ok(()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,3 @@ pub mod switcher;
 pub mod usb;
 #[cfg(windows)]
 pub mod windows;
-
-#[macro_export]
-#[doc(hidden)]
-macro_rules! S
-{
-    ($expr:expr) => {
-        String::from($expr)
-    };
-}

--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use clap::ArgMatches;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{eyre, Result};
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
 use directories::ProjectDirs;
@@ -18,8 +18,6 @@ use log::error;
 
 use crate::bmp::BmpDevice;
 use crate::bmp::BmpMatcher;
-use crate::error::Error;
-use crate::error::ErrorKind;
 use crate::flasher;
 use crate::metadata::download_metadata;
 use crate::metadata::structs::{Firmware, FirmwareDownload, Metadata, Probe};
@@ -275,7 +273,7 @@ fn download_firmware(variant: &FirmwareDownload, cache_path: &Path) -> Result<Pa
 
 impl ProbeIdentity
 {
-    fn variant(&self) -> Result<Probe, Error>
+    fn variant(&self) -> Result<Probe>
     {
         match &self.probe {
             Some(product) => {
@@ -294,11 +292,11 @@ impl ProbeIdentity
                     "st-link/v2" => Probe::Stlink,
                     "st-link v3" => Probe::Stlinkv3,
                     "swlink" => Probe::Swlink,
-                    _ => return Err(ErrorKind::DeviceSeemsInvalid("unknown product string encountered".into()).error()),
+                    _ => return Err(eyre!("Probe with unknown product string encountered")),
                 };
                 Ok(probe)
             },
-            None => Err(ErrorKind::DeviceSeemsInvalid("invalid product string".into()).error()),
+            None => Err(eyre!("Probe has invalid product string")),
         }
     }
 }


### PR DESCRIPTION
In this PR we aim to improve the user experience to make the download process smoother and suppress errors that are part of normal operation due to how the OS stack handles a device disappearing from a control request.

This should make error reports more useful and readable, this should also make them only occur on exceptional behaviour and real errors. This PR restores full function of the tool on macOS which was getting punked by spurious errors.