### PR TITLE
Feature: Better firmware selection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,12 +18,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
+name = "ansi-to-tui"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67555e1f1ece39d737e28c8a017721287753af3f93225e4a445b29ccb0f5912c"
+dependencies = [
+ "nom 7.1.3",
+ "ratatui",
+ "simdutf8",
+ "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -104,7 +129,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -120,6 +145,15 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bindgen"
@@ -196,6 +230,7 @@ dependencies = [
  "libc",
  "log",
  "nusb",
+ "ratatui",
  "rc-zip-sync",
  "reqwest",
  "rustc_version",
@@ -205,6 +240,7 @@ dependencies = [
  "static_vcruntime",
  "termcolor",
  "thiserror 2.0.12",
+ "tui-markdown",
  "url",
  "wdi",
  "winapi",
@@ -239,6 +275,21 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -321,7 +372,7 @@ dependencies = [
  "clap_lex",
  "terminal_size",
  "unicase",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -364,6 +415,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "console"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -372,7 +437,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.0",
  "windows-sys 0.59.0",
 ]
 
@@ -431,6 +496,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.9.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook 0.3.17",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -438,6 +528,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -452,6 +577,15 @@ dependencies = [
  "shared_library",
  "termwiz",
  "winapi",
+]
+
+[[package]]
+name = "deranged"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -491,6 +625,12 @@ dependencies = [
  "thiserror 1.0.69",
  "zeroize",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "diffy"
@@ -673,10 +813,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -774,6 +930,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +961,15 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -875,6 +1046,17 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1136,6 +1318,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1181,8 +1369,27 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.0",
  "web-time",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "instability"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf9fed6d91cfb734e7476a06bde8300a1b94e217e1b523b6f0cd1a01998c71d"
+dependencies = [
+ "darling",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -1217,6 +1424,24 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1311,6 +1536,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1329,10 +1560,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown",
+]
 
 [[package]]
 name = "mach2"
@@ -1377,12 +1627,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
@@ -1433,6 +1693,12 @@ dependencies = [
  "overload",
  "winapi",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -1526,6 +1792,28 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "onig"
+version = "6.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "opaque-debug"
@@ -1632,6 +1920,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pathsearch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1727,6 +2044,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plist"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac26e981c03a6e53e0aee43c113e3202f5581d5360dae7bd2c70e800dd0451d"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1753,6 +2083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,6 +2102,16 @@ name = "pretty-hex"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "prettyplease"
@@ -1816,6 +2162,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
+dependencies = [
+ "bitflags 2.9.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
+name = "quick-xml"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1948,6 +2322,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.9.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rc-zip"
 version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,7 +2352,7 @@ dependencies = [
  "chrono",
  "crc32fast",
  "encoding_rs",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
  "num_enum",
  "oem_cp",
  "oval",
@@ -1977,6 +2372,15 @@ dependencies = [
  "positioned-io",
  "rc-zip",
  "tracing",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+dependencies = [
+ "bitflags 2.9.0",
 ]
 
 [[package]]
@@ -2029,6 +2433,12 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
@@ -2092,6 +2502,36 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rstest"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fc39292f8613e913f7df8fa892b8944ceb47c247b78e1b1ae2f09e019be789d"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f168d99749d307be9de54d23fd226628d99768225ef08f6ffb52e0182a27746"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.100",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -2203,6 +2643,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2210,6 +2659,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
@@ -2388,6 +2843,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook 0.3.17",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2395,6 +2871,12 @@ checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -2434,10 +2916,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "static_vcruntime"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "954e3e877803def9dc46075bf4060147c55cd70db97873077232eae0269dc89b"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "subtle"
@@ -2485,6 +3001,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "syntect"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
+dependencies = [
+ "bincode",
+ "bitflags 1.3.2",
+ "flate2",
+ "fnv",
+ "once_cell",
+ "onig",
+ "plist",
+ "regex-syntax",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 1.0.69",
+ "walkdir",
+ "yaml-rust",
 ]
 
 [[package]]
@@ -2584,7 +3122,7 @@ dependencies = [
  "regex",
  "semver 0.11.0",
  "sha2 0.9.9",
- "signal-hook",
+ "signal-hook 0.1.17",
  "terminfo",
  "termios",
  "thiserror 1.0.69",
@@ -2642,6 +3180,37 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
+
+[[package]]
+name = "time-macros"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -2821,6 +3390,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tui-markdown"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf47229087fc49650d095a910a56aaf10c1c64181d042d2c2ba46fc3746ff534"
+dependencies = [
+ "ansi-to-tui",
+ "itertools 0.14.0",
+ "pretty_assertions",
+ "pulldown-cmark",
+ "ratatui",
+ "rstest",
+ "syntect",
+ "tracing",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2849,6 +3434,23 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2923,6 +3525,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3397,6 +4009,21 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ dialoguer = "0.11.0"
 directories = "6.0.0"
 sha2 = "0.10.8"
 color-eyre = "0.6.3"
+tui-markdown = "0.3.3"
+ratatui = "0.29.0"
 
 [target.'cfg(windows)'.dependencies]
 wdi = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ directories = "6.0.0"
 sha2 = "0.10.8"
 color-eyre = "0.6.3"
 tui-markdown = "0.3.3"
-ratatui = "0.29.0"
+ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
 
 [target.'cfg(windows)'.dependencies]
 wdi = "0.1.0"

--- a/src/docs_viewer.rs
+++ b/src/docs_viewer.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+
+use color_eyre::eyre::Result;
+use ratatui::buffer::Buffer;
+use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::layout::{Alignment, Rect};
+use ratatui::widgets::{Block, BorderType, Padding, Widget};
+use ratatui::DefaultTerminal;
+use ratatui::Frame;
+
+
+pub struct Viewer<'a>
+{
+    exit: bool,
+    title: &'a str,
+    docs: &'a str,
+}
+
+impl<'a> Viewer<'a>
+{
+    pub fn display(title: &'a String, docs: &'a String) -> Result<()>
+    {
+        // Grab the console, putting it in TUI mode
+        let mut terminal = ratatui::init();
+        // Turn the Markdown to display into a viewer
+        let mut viewer = Self::new(title, docs);
+
+        // Run the viewer and wait to see what the user does
+        let result = viewer.run(&mut terminal);
+        // When they get done, put the console back and propagate any errors
+        ratatui::restore();
+        result
+    }
+
+    fn new(title: &'a String, docs: &'a String) -> Self
+    {
+        Self {
+            exit: false,
+            title: title.as_str(),
+            docs: docs.as_str(),
+        }
+    }
+
+    fn run(&mut self, terminal: &mut DefaultTerminal) -> Result<()>
+    {
+        while !self.exit {
+            terminal.draw(|frame| self.draw(frame))?;
+            self.handle_events()?;
+        }
+        Ok(())
+    }
+
+    fn draw(&mut self, frame: &mut Frame)
+    {
+        frame.render_widget(self, frame.area())
+    }
+
+    fn handle_events(&mut self) -> Result<()>
+    {
+        match event::read()?
+        {
+            Event::Key(key) =>
+            {
+                if key.kind == KeyEventKind::Press {
+                    match key.code {
+                        KeyCode::Char('q' | 'Q') => self.quit(),
+                        _ => {},
+                    }
+                }
+            },
+            _ => {},
+        }
+        Ok(())
+    }
+
+    fn quit(&mut self)
+    {
+        self.exit = true
+    }
+}
+
+impl Widget for &mut Viewer<'_>
+{
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized
+    {
+        let docs_text = tui_markdown::from_str(self.docs);
+
+        // Build a bordered block for presentation
+        let block = Block::bordered()
+            .title(self.title)
+            .title_alignment(Alignment::Left)
+            .border_type(BorderType::Rounded)
+            .padding(Padding::horizontal(1));
+
+        // Render the contents of the block (the docs text), then the block itself
+        docs_text.render(block.inner(area), buf);
+        block.render(area, buf);
+    }
+}

--- a/src/docs_viewer.rs
+++ b/src/docs_viewer.rs
@@ -9,7 +9,8 @@ use ratatui::layout::{Alignment, Margin, Rect, Size};
 use ratatui::symbols::scrollbar;
 use ratatui::text::Text;
 use ratatui::widgets::{
-    Block, BorderType, Padding, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Widget
+    Block, BorderType, Padding, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget,
+    Widget
 };
 use ratatui::DefaultTerminal;
 use ratatui::Frame;
@@ -161,16 +162,18 @@ impl Widget for &mut Viewer<'_>
     where
         Self: Sized
     {
-        // Build a bordered block for presentation
-        let block = Block::bordered()
-            .title(self.title)
-            .title_alignment(Alignment::Left)
-            .border_type(BorderType::Rounded)
-            .padding(Padding::horizontal(1));
-
         // Render the contents of the block (the docs text), then the block itself
-        self.docs.clone().render(block.inner(area), buf);
-        block.render(area, buf);
+        Paragraph::new(self.docs.clone())
+            .scroll((self.scroll_position as u16, 0))
+            .block(
+                // Build a bordered block for presentation
+                Block::bordered()
+                    .title(self.title)
+                    .title_alignment(Alignment::Left)
+                    .border_type(BorderType::Rounded)
+                    .padding(Padding::horizontal(1))
+            )
+            .render(area, buf);
 
         // Build the scrollbar state
         let mut scroll_state = ScrollbarState::new(self.max_scroll)

--- a/src/docs_viewer.rs
+++ b/src/docs_viewer.rs
@@ -7,6 +7,7 @@ use ratatui::buffer::Buffer;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::layout::{Alignment, Margin, Rect, Size};
 use ratatui::symbols::scrollbar;
+use ratatui::text::Text;
 use ratatui::widgets::{
     Block, BorderType, Padding, Paragraph, Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget,
     Widget, Wrap
@@ -192,5 +193,10 @@ impl Widget for &mut Viewer<'_>
             buf,
             &mut scroll_state
         );
+
+        // Render the key bindings help
+        Text::from(" ⋏⋎: scroll, ⊼⊻: scroll page, q: quit to menu ")
+            .centered()
+            .render(area.rows().last().unwrap(), buf);
     }
 }

--- a/src/docs_viewer.rs
+++ b/src/docs_viewer.rs
@@ -80,6 +80,8 @@ impl<'a> Viewer<'a>
                 if key.kind == KeyEventKind::Press {
                     match key.code {
                         KeyCode::Char('q' | 'Q') => self.quit(),
+                        KeyCode::Up => self.scroll_up(),
+                        KeyCode::Down => self.scroll_down(),
                         _ => {},
                     }
                 }
@@ -106,6 +108,22 @@ impl<'a> Viewer<'a>
         }
         // Update the max scroll position too
         self.max_scroll = max_scroll;
+    }
+
+    fn scroll_up(&mut self)
+    {
+        // Scrolling up is easy.. just keep subtracting 1 until we reach 0 and keep it at 0
+        self.scroll_position = self.scroll_position.saturating_sub(1)
+    }
+
+    fn scroll_down(&mut self)
+    {
+        // Scrolling down is a bit harder - start by computing what the next scroll position should be
+        let new_position = self.scroll_position + 1;
+        // Now, if that does not exceed the actual max scroll position, we can update our scroll position
+        if new_position <= self.max_scroll {
+            self.scroll_position = new_position;
+        }
     }
 }
 

--- a/src/docs_viewer.rs
+++ b/src/docs_viewer.rs
@@ -5,7 +5,7 @@
 use color_eyre::eyre::Result;
 use ratatui::buffer::Buffer;
 use ratatui::crossterm::event::{self, Event, KeyCode, KeyEventKind};
-use ratatui::layout::{Alignment, Rect};
+use ratatui::layout::{Alignment, Rect, Size};
 use ratatui::widgets::{Block, BorderType, Padding, Widget};
 use ratatui::DefaultTerminal;
 use ratatui::Frame;
@@ -16,6 +16,8 @@ pub struct Viewer<'a>
     exit: bool,
     title: &'a str,
     docs: &'a str,
+
+    viewport_size: Size,
 }
 
 impl<'a> Viewer<'a>
@@ -25,7 +27,7 @@ impl<'a> Viewer<'a>
         // Grab the console, putting it in TUI mode
         let mut terminal = ratatui::init();
         // Turn the Markdown to display into a viewer
-        let mut viewer = Self::new(title, docs);
+        let mut viewer = Self::new(title, docs, terminal.size()?);
 
         // Run the viewer and wait to see what the user does
         let result = viewer.run(&mut terminal);
@@ -34,12 +36,13 @@ impl<'a> Viewer<'a>
         result
     }
 
-    fn new(title: &'a String, docs: &'a String) -> Self
+    fn new(title: &'a String, docs: &'a String, viewport_size: Size) -> Self
     {
         Self {
             exit: false,
             title: title.as_str(),
             docs: docs.as_str(),
+            viewport_size,
         }
     }
 
@@ -70,6 +73,7 @@ impl<'a> Viewer<'a>
                     }
                 }
             },
+            Event::Resize(width, height) => self.viewport_size = Size::new(width, height),
             _ => {},
         }
         Ok(())

--- a/src/firmware_selector.rs
+++ b/src/firmware_selector.rs
@@ -15,6 +15,7 @@ use crate::metadata::structs::FirmwareDownload;
 pub struct FirmwareMultichoice<'a>
 {
     state: State,
+    release: &'a str,
     variants: Vec<&'a FirmwareDownload>,
     friendly_names: Vec<&'a str>,
 }
@@ -32,7 +33,7 @@ enum State
 
 impl<'a> FirmwareMultichoice<'a>
 {
-    pub fn new(variants: &'a BTreeMap<String, FirmwareDownload>) -> Self
+    pub fn new(release: &'a str, variants: &'a BTreeMap<String, FirmwareDownload>) -> Self
     {
         // Map the variant list to create selection items
         let friendly_names: Vec<_> = variants
@@ -43,6 +44,7 @@ impl<'a> FirmwareMultichoice<'a>
         // Construct the new multi-choice object that will start in the default firmware selection state
         Self {
             state: State::default(),
+            release,
             variants: variants.values().collect(),
             friendly_names
         }

--- a/src/firmware_selector.rs
+++ b/src/firmware_selector.rs
@@ -62,6 +62,10 @@ impl<'a> FirmwareMultichoice<'a>
         self.state = match self.state {
             State::PickFirmware => self.firmware_selection()?,
             State::PickAction(index) => self.action_selection(index)?,
+            // FlashFirmware and Cancel are both terminal actions whereby the FSM is done,
+            // so maintain homeostatis for them here.
+            State::FlashFirmware(index) => State::FlashFirmware(index),
+            State::Cancel => State::Cancel,
             _ => todo!(),
         };
 

--- a/src/firmware_selector.rs
+++ b/src/firmware_selector.rs
@@ -3,9 +3,10 @@
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
 
 use std::collections::BTreeMap;
+use std::path::PathBuf;
+use std::time::Duration;
 
-use color_eyre::eyre::eyre;
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{eyre, Result};
 use dialoguer::theme::ColorfulTheme;
 use dialoguer::Select;
 
@@ -24,7 +25,7 @@ enum State
     #[default]
     PickFirmware,
     PickAction(usize),
-    ShowDocs(usize),
+    ShowDocs(usize, usize),
     FlashFirmware(usize),
     Cancel,
 }
@@ -62,11 +63,12 @@ impl<'a> FirmwareMultichoice<'a>
         self.state = match self.state {
             State::PickFirmware => self.firmware_selection()?,
             State::PickAction(index) => self.action_selection(index)?,
+            State::ShowDocs(name_index, variant_index) =>
+                self.show_documentation(name_index, variant_index)?,
             // FlashFirmware and Cancel are both terminal actions whereby the FSM is done,
             // so maintain homeostatis for them here.
             State::FlashFirmware(index) => State::FlashFirmware(index),
             State::Cancel => State::Cancel,
-            _ => todo!(),
         };
 
         Ok(())
@@ -95,11 +97,11 @@ impl<'a> FirmwareMultichoice<'a>
         })
     }
 
-    fn action_selection(&self, index: usize) -> Result<State>
+    fn action_selection(&self, name_index: usize) -> Result<State>
     {
         // Convert from a friendly name index into the matching variant download
-        let friendly_name = self.friendly_names[index];
-        let (index, _) = self.variants
+        let friendly_name = self.friendly_names[name_index];
+        let (variant_index, _) = self.variants
             .iter()
             .enumerate()
             .find(|(_, variant)| variant.friendly_name == friendly_name)
@@ -114,12 +116,38 @@ impl<'a> FirmwareMultichoice<'a>
 
         Ok(match selection {
             Some(item) => match item {
-                0 => State::FlashFirmware(index),
-                1 => State::ShowDocs(index),
+                0 => State::FlashFirmware(variant_index),
+                1 => State::ShowDocs(name_index, variant_index),
                 2 => State::PickFirmware,
                 _ => Err(eyre!("Impossible selection for action"))?
             },
             None => State::Cancel,
         })
+    }
+
+    fn show_documentation(&self, name_index: usize, variant_index: usize) -> Result<State>
+    {
+        // Extract which firmware download we're to work with
+        let variant = self.variants[variant_index];
+        // Convert the path compoment of the download URI to a Path
+        let mut docs_path = PathBuf::from(variant.uri.path());
+        // Replace the file extension from ".elf" to ".md"
+        docs_path.set_extension("md");
+        // Convert back into a URI
+        let mut docs_uri = variant.uri.clone();
+        docs_uri.set_path(
+            docs_path.to_str()
+                .expect("Something went terribly wrong building the documentation URI")
+        );
+
+        // Now try and download this documentation file
+        let client = reqwest::blocking::Client::new();
+        let response = client.get(docs_uri)
+            // Use a 2 second timeout so we don't get stuck forever if the user is
+            // having connectivity problems - better to die early and have them retry
+            .timeout(Duration::from_secs(2))
+            .send()?;
+
+        Ok(State::PickAction(name_index))
     }
 }

--- a/src/firmware_selector.rs
+++ b/src/firmware_selector.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+
+use std::collections::BTreeMap;
+
+use color_eyre::eyre::eyre;
+use color_eyre::eyre::Result;
+use dialoguer::theme::ColorfulTheme;
+use dialoguer::Select;
+
+use crate::metadata::structs::FirmwareDownload;
+
+pub struct FirmwareMultichoice<'a>
+{
+    state: State,
+    variants: Vec<&'a FirmwareDownload>,
+    friendly_names: Vec<&'a str>,
+}
+
+#[derive(Default)]
+enum State
+{
+    #[default]
+    PickFirmware,
+    PickAction(usize),
+    ShowDocs(usize),
+    FlashFirmware(usize),
+    Cancel,
+}
+
+impl<'a> FirmwareMultichoice<'a>
+{
+    pub fn new(variants: &'a BTreeMap<String, FirmwareDownload>) -> Self
+    {
+        // Map the variant list to create selection items
+        let friendly_names: Vec<_> = variants
+            .iter()
+            .map(|(_, variant)| variant.friendly_name.as_str())
+            .collect();
+
+        // Construct the new multi-choice object that will start in the default firmware selection state
+        Self {
+            state: State::default(),
+            variants: variants.values().collect(),
+            friendly_names
+        }
+    }
+
+    /// Returns true if the FSM is finished and there are no further state transitions to go
+    pub fn complete(&self) -> bool
+    {
+        match self.state {
+            State::FlashFirmware(_) | State::Cancel => true,
+            _ => false,
+        }
+    }
+
+    /// Step the FSM and perform the actions associated with that step
+    pub fn step(&mut self) -> Result<()>
+    {
+        self.state = match self.state {
+            State::PickFirmware => self.firmware_selection()?,
+            State::PickAction(index) => self.action_selection(index)?,
+            _ => todo!(),
+        };
+
+        Ok(())
+    }
+
+    /// Convert the FSM state into a firmware download selection
+    pub fn selection(&self) -> Option<&'a FirmwareDownload>
+    {
+        match self.state {
+            State::FlashFirmware(index) => Some(self.variants[index]),
+            _ => None,
+        }
+    }
+
+    fn firmware_selection(&self) -> Result<State>
+    {
+        // Figure out which one the user wishes to use
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("Which firmware variant would you like to run on your probe?")
+            .items(self.friendly_names.as_slice())
+            .interact_opt()?;
+        // Encode the result into a new FSM state
+        Ok(match selection {
+            Some(index) => State::PickAction(index),
+            None => State::Cancel,
+        })
+    }
+
+    fn action_selection(&self, index: usize) -> Result<State>
+    {
+        // Convert from a friendly name index into the matching variant download
+        let friendly_name = self.friendly_names[index];
+        let (index, _) = self.variants
+            .iter()
+            .enumerate()
+            .find(|(_, variant)| variant.friendly_name == friendly_name)
+            .unwrap(); // Can't fail anyway..
+
+        // Ask the user what they wish to do
+        let items = ["Flash to probe", "Show documentation", "Choose a different variant"];
+        let selection = Select::with_theme(&ColorfulTheme::default())
+            .with_prompt("What action would you like to take with this firmware?")
+            .items(&items)
+            .interact_opt()?;
+
+        Ok(match selection {
+            Some(item) => match item {
+                0 => State::FlashFirmware(index),
+                1 => State::ShowDocs(index),
+                2 => State::PickFirmware,
+                _ => Err(eyre!("Impossible selection for action"))?
+            },
+            None => State::Cancel,
+        })
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@
 pub mod bmp;
 pub mod error;
 pub mod elf;
+pub mod firmware_selector;
 pub mod flasher;
 pub mod metadata;
 pub mod switcher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 // SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 
 pub mod bmp;
+pub mod docs_viewer;
 pub mod error;
 pub mod elf;
 pub mod firmware_selector;


### PR DESCRIPTION
In this PR we implement a better firmware selection system for multi-variant firmware.

The way this works is that after picking a firmware variant from the list, the user is presented with a secondary action menu - do they want to Flash the firmware on their probe, view documentation about the variant, or pick a different variant; this is handled by a small FSM so they can go back and forth between the variant list and action menu as much as they like.

If the user picks the documentation, the utility downloads a Markdown file co-located with the firmware .elf and switches into a ratatui-based TUI to display it with scrolling etc - when they get done, they can tap `q` to get back to the action menu and either Flash the selection or pick something else. A user can always cancel with `q` at any time.

This solves the final major usability and UX problem with this new portion of the tool, allowing users to read about what a variant is before committing to it.