### PR TITLE
Fix: spurious STALL errors under Linux

### DIFF
--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -134,10 +134,12 @@ impl Firmware
                             // bootloader rebooting and we can safely ignore it
                             #[cfg(any(target_os = "linux", target_os = "android"))]
                             TransferError::Disconnected => Ok(()),
-                            // If the error reported on Windows was a STALL, that was just the
+                            // If the error reported was a STALL, that was just the
                             // bootloader rebooting and we can safely ignore it
-                            #[cfg(any(target_os = "windows", target_os = "macos"))]
                             TransferError::Stall => Ok(()),
+                            // If the error reported on macOS was unknown, this is most probably just the
+                            // OS having a bad time tracking the result of the detach packet and the
+                            // device rebooting as a result, so we can safely ignore it
                             #[cfg(target_os = "macos")]
                             TransferError::Unknown => Ok(()),
                             _ => {


### PR DESCRIPTION
In this PR we expand the STALL error suppression to all OSes to address an issue reported on Discord shortly after the v1.0.0-rc.1 release.

In this report, the user got a spurious STALL error from their probe as it rebooted back from the bootloader into the new firmware. Linux was the last supported OS for which this was not suppressed.