### PR TITLE
Fix: Windows disconnect suppression

### DIFF
--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -132,7 +132,7 @@ impl Firmware
                         DfuNusbError::Transfer(error) => match error {
                             // If the error reported on Linux was a disconnection, that was just the
                             // bootloader rebooting and we can safely ignore it
-                            #[cfg(any(target_os = "linux", target_os = "android"))]
+                            #[cfg(any(target_os = "linux", target_os = "android", target_os = "windows"))]
                             TransferError::Disconnected => Ok(()),
                             // If the error reported was a STALL, that was just the
                             // bootloader rebooting and we can safely ignore it


### PR DESCRIPTION
In this PR we address a missing suppression for errors during the reboot to firmware process on Windows.

Reported by yeskinger on Discord, this would result in a spurious disconnection error being displayed rather than the process completing successfully.