### PR TITLE
Feature: CLI Restructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -370,9 +371,22 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
  "terminal_size",
  "unicase",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
@@ -92,12 +92,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -121,17 +121,17 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "backtrace"
-version = "0.3.71"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.4",
+ "miniz_oxide 0.8.8",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -161,7 +161,7 @@ version = "0.66.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -174,7 +174,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.100",
+ "syn 2.0.101",
  "which",
 ]
 
@@ -186,9 +186,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "block-buffer"
@@ -236,7 +236,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "static_vcruntime",
  "termcolor",
  "thiserror 2.0.12",
@@ -293,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "shlex",
 ]
@@ -334,9 +334,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "num-traits",
 ]
@@ -354,18 +354,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.36"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.36"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -383,9 +383,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "color-eyre"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -398,9 +398,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -501,12 +501,12 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
  "rustix 0.38.44",
- "signal-hook 0.3.17",
+ "signal-hook 0.3.18",
  "signal-hook-mio",
  "winapi",
 ]
@@ -551,7 +551,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -562,7 +562,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -709,7 +709,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -777,9 +777,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -914,7 +914,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -974,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -987,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1001,9 +1001,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
@@ -1024,9 +1024,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75249d144030531f8dee69fe9cea04d3edf809a017ae445e2abdff6629e86633"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1060,9 +1060,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -1147,11 +1147,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -1181,41 +1180,48 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1225,30 +1231,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7515e6d781098bf9f7205ab3fc7e9709d34554ae0b21ddbcb5febfa4bc7df11d"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -1256,65 +1242,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e8338228bdc8ab83303f16b797e177953730f601a96c25d10cb3ab0daa0cb7"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85fb8799753b75aee8d2a21d7c14d9f38921b54b3dbda10f5a3c7a7b82dba5e2"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -1336,9 +1309,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1389,7 +1362,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1407,6 +1380,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
@@ -1451,9 +1434,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jiff"
-version = "0.2.8"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ad87c89110f55e4cd4dc2893a9790820206729eaf221555f742d540b0724a0"
+checksum = "a194df1107f33c79f4f93d02c80798520551949d59dfad22b6157048a88cca93"
 dependencies = [
  "jiff-static",
  "log",
@@ -1464,13 +1447,13 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.8"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d076d5b64a7e2fe6f0743f02c43ca4a6725c0f904203bfe276a5b3e793103605"
+checksum = "6c6e1db7ed32c6c71b759497fae34bf7933636f75a251b9e736555da426f6442"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1497,18 +1480,18 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libloading"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
+checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.52.6",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
@@ -1517,7 +1500,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "libc",
 ]
 
@@ -1555,15 +1538,15 @@ checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1583,6 +1566,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mach2"
@@ -1637,14 +1626,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1738,7 +1727,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1749,9 +1738,9 @@ checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "nusb"
-version = "0.1.13"
+version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a726776e551f3ee9b467fe47202f26e64b9bbf715df5443b0904df6f2dcc41"
+checksum = "2f861541f15de120eae5982923d073bfc0c1a65466561988c82d6e197734c19e"
 dependencies = [
  "atomic-waker",
  "core-foundation",
@@ -1768,9 +1757,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1794,12 +1783,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "onig"
-version = "6.4.0"
+name = "once_cell_polyfill"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c4b31c8722ad9171c6d77d3557db078cab2bd50afcc9d09c8b315c59df8ca4f"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "onig"
+version = "6.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.9.1",
  "libc",
  "once_cell",
  "onig_sys",
@@ -1807,9 +1802,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.8.1"
+version = "69.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b829e3d7e9cc74c7e315ee8edb185bf4190da5acde74afd7fc59c35b1f086e7"
+checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
 dependencies = [
  "cc",
  "pkg-config",
@@ -1823,11 +1818,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.72"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1844,7 +1839,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1855,9 +1850,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.107"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1910,20 +1905,20 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1931,9 +1926,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2083,6 +2078,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,12 +2119,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2157,9 +2161,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -2170,7 +2174,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e8bbe1a966bd2f362681a44f6edce3c2310ac21e4d5067a6e7ec396297a6ea0"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -2194,9 +2198,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.7"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3bd15a6f2967aef83887dcb9fec0014580467e33720d073560cf015a5683012"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2214,13 +2218,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.10"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b820744eb4dc9b57a3398183639c511b5a26d2ed702cedd3febaa1393caa22cc"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom 0.3.2",
- "rand 0.9.0",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
@@ -2234,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "541d0f57c6ec747a90738a52741d3221f7960e8ac2f0ff4b1a63680e033b4ab5"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2274,13 +2279,12 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
- "zerocopy",
 ]
 
 [[package]]
@@ -2309,7 +2313,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2318,7 +2322,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -2327,7 +2331,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -2364,9 +2368,9 @@ dependencies = [
 
 [[package]]
 name = "rc-zip-sync"
-version = "4.2.6"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd21d17384a7da18df6b70f49bc2daa84d15e0fa0929bc635541383b3827190"
+checksum = "dc9658d8ace392ab7f2b149ae6c40bea7a3d70ebc39aaa6c7076ddc3f11c9c32"
 dependencies = [
  "oval",
  "positioned-io",
@@ -2376,11 +2380,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2389,7 +2393,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -2400,7 +2404,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
 ]
@@ -2442,9 +2446,9 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -2470,24 +2474,22 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots",
- "windows-registry",
 ]
 
 [[package]]
@@ -2498,7 +2500,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2530,7 +2532,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-ident",
 ]
 
@@ -2567,7 +2569,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -2576,11 +2578,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -2589,9 +2591,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.26"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
  "once_cell",
  "ring",
@@ -2602,28 +2604,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.1"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2632,9 +2626,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -2683,7 +2677,7 @@ checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2692,7 +2686,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2750,7 +2744,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2792,9 +2786,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -2844,9 +2838,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -2860,14 +2854,14 @@ checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
  "mio",
- "signal-hook 0.3.17",
+ "signal-hook 0.3.18",
 ]
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -2901,9 +2895,9 @@ checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -2952,7 +2946,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2974,9 +2968,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2994,13 +2988,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3031,7 +3025,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -3048,14 +3042,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
- "getrandom 0.3.2",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -3074,7 +3068,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
 dependencies = [
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -3158,7 +3152,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3169,7 +3163,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3215,9 +3209,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3240,9 +3234,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -3275,9 +3269,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -3288,19 +3282,19 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow 0.7.6",
+ "winnow 0.7.10",
 ]
 
 [[package]]
@@ -3314,6 +3308,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -3349,7 +3361,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3391,9 +3403,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tui-markdown"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf47229087fc49650d095a910a56aaf10c1c64181d042d2c2ba46fc3746ff534"
+checksum = "d10648c25931bfaaf5334ff4e7dc5f3d830e0c50d7b0119b1d5cfe771f540536"
 dependencies = [
  "ansi-to-tui",
  "itertools 0.14.0",
@@ -3481,12 +3493,6 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -3583,7 +3589,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -3618,7 +3624,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3665,9 +3671,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2210b291f7ea53617fbafcc4939f10914214ec15aace5ba62293a668f322c5c9"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -3734,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "windows-result"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c64fd11a4fd95df68efcfee5f44a294fe71b8bc6a91993e2791938abcc712252"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link",
 ]
@@ -3973,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
 ]
@@ -3995,20 +4001,14 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "yaml-rust"
@@ -4027,9 +4027,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -4039,34 +4039,34 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4086,7 +4086,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -4097,10 +4097,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4109,11 +4120,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "static_vcruntime",
- "termcolor",
  "thiserror 2.0.12",
  "tui-markdown",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "anyhow",
  "bstr",
  "clap",
+ "clap_complete",
  "color-eyre",
  "const_format",
  "deelevate",
@@ -375,6 +376,15 @@ dependencies = [
  "terminal_size",
  "unicase",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a554639e42d0c838336fc4fbedb9e2df3ad1fa4acda149f9126b4ccfcd7900f"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ const_format = "0.2"
 anyhow = "1.0"
 thiserror = "2.0"
 indicatif = "0.17"
-termcolor = "1.4"
 goblin = { version = "0.9", default-features = false, features = ["std", "elf32", "elf64", "endian_fd"] }
 libc = "0.2"
 bstr = "1.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ default-run = "bmputil-cli"
 
 [dependencies]
 anstyle = "1.0"
-clap = { version = "4.0", default-features = false, features = ["std", "color", "help", "usage", "unicode", "wrap_help", "unstable-styles", "cargo"] }
+clap = { version = "4.0", default-features = false, features = ["std", "color", "help", "usage", "unicode", "wrap_help", "cargo", "derive", "suggestions"] }
 env_logger = "0.11"
 dfu-core = { version = "0.7.0", features = ["std"] }
 dfu-nusb = "0.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ sha2 = "0.10.8"
 color-eyre = "0.6.3"
 tui-markdown = "0.3.3"
 ratatui = { version = "0.29.0", features = ["unstable-rendered-line-info"] }
+clap_complete = "4.5.52"
 
 [target.'cfg(windows)'.dependencies]
 wdi = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bmputil"
-description = "Black Magic Probe Firmware Manager"
+description = "Black Magic Probe companion utility"
 version = "1.0.0-rc.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/blackmagic-debug/bmputil"

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 use clap::builder::TypedValueParser;
 use clap::{Arg, ArgAction, Args, Command, Parser, Subcommand};
 use clap::builder::styling::Styles;
-use color_eyre::eyre::{Context, Result};
+use color_eyre::eyre::{eyre, Context, Result};
 use directories::ProjectDirs;
 use log::{info, error};
 
@@ -71,7 +71,7 @@ enum ProbeCommmands
     Update(UpdateArguments),
     /// Switch the firmware being used on a given probe
     Switch(SwitchArguments),
-    // Reboot a Black Magic Probe (potentially into its bootloader)
+    /// Reboot a Black Magic Probe (potentially into its bootloader)
     Reboot(RebootArguments),
     #[cfg(windows)]
     /// Install USB drivers for BMP devices, and quit
@@ -89,7 +89,7 @@ struct InfoArguments
 #[derive(Args)]
 struct UpdateArguments
 {
-    firmware_binary: String,
+    firmware_binary: Option<String>,
     #[arg(long = "override-firmware-type", hide_short_help = true, value_enum)]
     /// Flash the specified firmware space regardless of autodetected firmware type
     override_firmware_type: Option<FirmwareType>,
@@ -236,7 +236,11 @@ fn reboot_command(cli_args: &CliArguments, reboot_args: &RebootArguments) -> Res
 
 fn update_probe(cli_args: &CliArguments, flash_args: &UpdateArguments) -> Result<()>
 {
-    let file_name = flash_args.firmware_binary.as_str();
+    let file_name = if let Some(file_name) = &flash_args.firmware_binary {
+        file_name.as_str()
+    } else {
+        return Err(eyre!("TODO: handle when the binary is not given and do an upgrade using metadata"));
+    };
 
     // Try to find the Black Magic Probe device based on the filter arguments.
     let matcher = BmpMatcher::from_params(cli_args);

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -378,7 +378,7 @@ fn main() -> Result<()>
 {
     color_eyre::install()?;
     env_logger::Builder::new()
-        .filter_level(log::LevelFilter::Warn)
+        .filter_level(log::LevelFilter::Info)
         .parse_default_env()
         .init();
 

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -4,11 +4,13 @@
 // SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 
 use std::ffi::OsStr;
+use std::io::stdout;
 use std::str::FromStr;
 
 use clap::builder::TypedValueParser;
-use clap::{Arg, ArgAction, Args, Command, Parser, Subcommand};
+use clap::{Arg, ArgAction, Args, Command, CommandFactory, Parser, Subcommand};
 use clap::builder::styling::Styles;
+use clap_complete::{generate, Shell};
 use color_eyre::eyre::{eyre, Context, Result};
 use directories::ProjectDirs;
 use log::{info, error};
@@ -47,6 +49,8 @@ enum ToplevelCommmands
 {
     /// Actions to be performed against a probe
     Probe(ProbeArguments),
+    /// Generate completions data for the shell
+    Complete(CompletionArguments),
 }
 
 #[derive(Args)]
@@ -138,6 +142,12 @@ struct DriversArguments
     #[arg(long = "force", default_value_t = false)]
     /// Install the driver even if one is already installed
     force: bool,
+}
+
+#[derive(Args)]
+struct CompletionArguments
+{
+    shell: Shell,
 }
 
 impl BmpParams for CliArguments
@@ -400,6 +410,16 @@ fn main() -> Result<()>
                 );
                 Ok(())
             },
-        }
+        },
+        ToplevelCommmands::Complete(comp_args) => {
+            let mut cmd = CliArguments::command();
+            generate(
+                comp_args.shell,
+                &mut cmd,
+                "bmputil-cli",
+                &mut stdout()
+            );
+            Ok(())
+        },
     }
 }

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -13,7 +13,7 @@ use clap::builder::styling::Styles;
 use clap_complete::{generate, Shell};
 use color_eyre::eyre::{Context, OptionExt, Result};
 use directories::ProjectDirs;
-use log::{error, info};
+use log::{error, info, warn};
 
 use bmputil::{AllowDangerous, BmpParams, FlashParams};
 use bmputil::bmp::{BmpDevice, BmpMatcher, FirmwareType};
@@ -49,6 +49,12 @@ enum ToplevelCommmands
 {
     /// Actions to be performed against a probe
     Probe(ProbeArguments),
+    /// Actions to be performed against a target connected to a probe
+    Target,
+    /// Actions that run the tool as a debug/tracing server
+    Server,
+    /// Actions that run debugging commands against a target connected to a probe
+    Debug,
     /// Generate completions data for the shell
     Complete(CompletionArguments),
 }
@@ -469,6 +475,18 @@ fn main() -> Result<()>
                 Ok(())
             },
         },
+        ToplevelCommmands::Target => {
+            warn!("Command space reserved for future tool version");
+            Ok(())
+        }
+        ToplevelCommmands::Server => {
+            warn!("Command space reserved for future tool version");
+            Ok(())
+        }
+        ToplevelCommmands::Debug => {
+            warn!("Command space reserved for future tool version");
+            Ok(())
+        }
         ToplevelCommmands::Complete(comp_args) => {
             let mut cmd = CliArguments::command();
             generate(

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -6,7 +6,6 @@
 use std::ffi::OsStr;
 use std::str::FromStr;
 
-use anstyle;
 use clap::builder::TypedValueParser;
 use clap::{Arg, ArgAction, Args, Command, Parser, Subcommand};
 use clap::builder::styling::Styles;
@@ -117,7 +116,7 @@ impl BmpParams for CliArguments
 
     fn serial_number(&self) -> Option<&str>
     {
-        self.serial_number.as_ref().map(|serial| serial.as_str())
+        self.serial_number.as_deref()
     }
 
     fn allow_dangerous_options(&self) -> AllowDangerous

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -12,7 +12,6 @@ use std::time::{Duration, Instant};
 use std::fmt::{self, Display, Formatter};
 use std::array::TryFromSliceError;
 
-use clap::ArgMatches;
 use clap::builder::PossibleValue;
 use clap::ValueEnum;
 use color_eyre::eyre::{eyre, Context, Error, Report, Result};
@@ -28,6 +27,7 @@ use nusb::descriptors::Descriptor;
 use dfu_nusb::{DfuNusb, Error as DfuNusbError};
 use dfu_core::{State as DfuState, Error as DfuCoreError};
 
+use crate::BmpParams;
 use crate::error::ErrorKind;
 use crate::usb::{DfuFunctionalDescriptor, InterfaceClass, InterfaceSubClass, GenericDescriptorRef, DfuRequest, PortId};
 use crate::usb::{Vid, Pid, DfuOperatingMode};
@@ -750,11 +750,13 @@ impl BmpMatcher
         Default::default()
     }
 
-    pub fn from_cli_args(matches: &ArgMatches) -> Self
+    pub fn from_params<Params>(params: &Params) -> Self
+    where
+        Params: BmpParams,
     {
         Self::new()
-            .index(matches.get_one::<usize>("index").map(|&value| value))
-            .serial(matches.get_one::<String>("serial_number").map(|s| s.as_str()))
+            .index(params.index())
+            .serial(params.serial_number())
             .port(None)
     }
 

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -27,6 +27,7 @@ use nusb::descriptors::Descriptor;
 use dfu_nusb::{DfuNusb, Error as DfuNusbError};
 use dfu_core::{State as DfuState, Error as DfuCoreError};
 
+use crate::probe_identity::ProbeIdentity;
 use crate::BmpParams;
 use crate::error::ErrorKind;
 use crate::usb::{DfuFunctionalDescriptor, InterfaceClass, InterfaceSubClass, GenericDescriptorRef, DfuRequest, PortId};
@@ -203,7 +204,7 @@ impl BmpDevice
     ///
     /// This is characterised by the product string which defines
     /// which kind of BMD-running thing we have and what version it runs
-    pub fn firmware_identity(&self) -> Result<String>
+    pub fn firmware_identity(&self) -> Result<ProbeIdentity>
     {
         self
             .device()
@@ -216,6 +217,7 @@ impl BmpDevice
                 |e| ErrorKind::DeviceSeemsInvalid("no product string descriptor".into())
                     .error_from(e).into()
             )
+            .and_then(|identity| identity.try_into())
     }
 
     /// Returns a string that represents the full port of the device, in the format of

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -489,7 +489,6 @@ impl BmpDevice
             .override_address(load_address);
 
         debug!("Load address: 0x{:08x}", load_address);
-        info!("Performing flash...");
 
         match self.try_download(firmware, length, &mut dfu_iface) {
             Err(error) => if let Some(DfuNusbError::Dfu(DfuCoreError::StateError(DfuState::DfuError))) =
@@ -518,8 +517,6 @@ impl BmpDevice
             },
             result => result,
         }?;
-
-        info!("Flash complete!");
 
         Ok(dfu_iface)
     }

--- a/src/bmp.rs
+++ b/src/bmp.rs
@@ -13,6 +13,8 @@ use std::fmt::{self, Display, Formatter};
 use std::array::TryFromSliceError;
 
 use clap::ArgMatches;
+use clap::builder::PossibleValue;
+use clap::ValueEnum;
 use color_eyre::eyre::{eyre, Context, Error, Report, Result};
 use dfu_core::DfuIo;
 use dfu_core::DfuProtocol;
@@ -685,6 +687,22 @@ impl Default for FirmwareType
     }
 }
 
+impl ValueEnum for FirmwareType
+{
+    fn value_variants<'a>() -> &'a [Self]
+    {
+        &[Self::Application, Self::Bootloader]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue>
+    {
+        match self {
+            Self::Bootloader => Some("bootloader".into()),
+            Self::Application => Some("application".into()),
+        }
+    }
+}
+
 
 /// File formats that Black Magic Probe firmware can be in.
 pub enum FirmwareFormat
@@ -716,8 +734,6 @@ impl FirmwareFormat
         }
     }
 }
-
-
 
 #[derive(Debug, Clone, Default)]
 pub struct BmpMatcher

--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -13,7 +13,7 @@ use color_eyre::eyre::{eyre, Context, Result};
 use color_eyre::owo_colors::OwoColorize;
 use dfu_nusb::Error as DfuNusbError;
 use indicatif::{ProgressBar, ProgressStyle};
-use log::{debug, error, warn};
+use log::{debug, error, info, warn};
 use nusb::transfer::TransferError;
 
 use crate::bmp::{self, BmpDevice, FirmwareFormat, FirmwareType};
@@ -115,6 +115,7 @@ impl Firmware
         );
         progress_bar.finish();
         let dfu_iface = result?;
+        info!("Flash complete!");
 
         if progress_bar.position() == (self.length as u64) {
             match device.reboot(dfu_iface) {

--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -19,7 +19,6 @@ use nusb::transfer::TransferError;
 use crate::bmp::{self, BmpDevice, FirmwareFormat, FirmwareType};
 use crate::{elf, AllowDangerous, BmpParams, FlashParams};
 use crate::usb::PortId;
-use crate::probe_identity::Version;
 
 pub struct Firmware
 {
@@ -208,10 +207,7 @@ fn check_programming(port: PortId) -> Result<()>
             e
         })?;
 
-    let version_string = match identity.version {
-        Version::Unknown => " <invalid version>".into(),
-        Version::Known(version) => version
-    };
+    let version_string = identity.version.to_string();
 
     println!("Black Magic Probe successfully rebooted into firmware version {}", version_string);
 

--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -207,9 +207,7 @@ fn check_programming(port: PortId) -> Result<()>
             e
         })?;
 
-    let version_string = identity.version.to_string();
-
-    println!("Black Magic Probe successfully rebooted into firmware version {}", version_string);
+    println!("Black Magic Probe successfully rebooted into firmware version {}", identity.version);
 
     Ok(())
 }

--- a/src/flasher.rs
+++ b/src/flasher.rs
@@ -10,11 +10,11 @@ use std::thread;
 use std::time::Duration;
 
 use color_eyre::eyre::{eyre, Context, Result};
+use color_eyre::owo_colors::OwoColorize;
 use dfu_nusb::Error as DfuNusbError;
 use indicatif::{ProgressBar, ProgressStyle};
 use log::{debug, error, warn};
 use nusb::transfer::TransferError;
-use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use crate::bmp::{self, BmpDevice, FirmwareFormat, FirmwareType};
 use crate::{elf, AllowDangerous, BmpParams, FlashParams};
@@ -65,22 +65,15 @@ impl Firmware
                     AllowDangerous::Really =>
                         warn!("Overriding firmware-type detection and flashing to user-specified location ({}) instead!", override_firmware_type),
                     AllowDangerous::Never => {
-                        // We're ignoring errors for setting the color because the most important thing is
-                        // getting the message itself out.
-                        // If the messages themselves don't write, though, then we might as well just panic.
-                        let mut stderr = StandardStream::stderr(ColorChoice::Auto);
-                        let _res = stderr.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
-                        write!(&mut stderr, "WARNING: ").expect("failed to write to stderr");
-                        let _res = stderr.reset();
-                        writeln!(
-                            &mut stderr,
-                            "--override-firmware-type is used to override the firmware type detection and flash \
+                        eprintln!(
+                            "{} --override-firmware-type is used to override the firmware type detection and flash \
                             a firmware binary to a location other than the one that it seems to be designed for.\n\
                             This is a potentially destructive operation and can result in an unbootable device! \
                             (can require a second, external JTAG debugger and manual wiring to fix!)\n\
                             \nDo not use this option unless you are a firmware developer and really know what you are doing!\n\
-                            \nIf you are sure this is really what you want to do, run again with --allow-dangerous-options=really"
-                        ).expect("failed to write to stderr");
+                            \nIf you are sure this is really what you want to do, run again with --allow-dangerous-options=really",
+                            "WARNING:".red()
+                        );
                         std::process::exit(1);
                     }
                 }
@@ -162,22 +155,11 @@ impl Firmware
 
 fn intel_hex_error() -> !
 {
-    // We're ignoring errors for setting the color because the most important thing
-    // is getting the message itself out.
-    // If the messages themselves don't write, though, then we might as well just panic.
-    let mut stderr = StandardStream::stderr(ColorChoice::Auto);
-    let _res = stderr.set_color(ColorSpec::new().set_fg(Some(Color::Red)));
-    write!(&mut stderr, "Error: ")
-        .expect("failed to write to stderr");
-    let _res = stderr.reset();
-    writeln!(
-        &mut stderr,
-        "The specified firmware file appears to be an Intel HEX file, but Intel HEX files are not \
+    eprintln!(
+        "{} The specified firmware file appears to be an Intel HEX file, but Intel HEX files are not \
         currently supported. Please use a binary file (e.g. blackmagic.bin), \
-        or an ELF (e.g. blackmagic.elf) to flash.",
-    )
-    .expect("failed to write to stderr");
-
+        or an ELF (e.g. blackmagic.elf) to flash.", "Error:".red()
+    );
     std::process::exit(1);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,9 @@
 // SPDX-FileContributor: Written by Piotr Esden-Tempski <piotr@esden.net>
 // SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 
+use clap::builder::PossibleValue;
+use clap::ValueEnum;
+
 use crate::bmp::FirmwareType;
 
 pub mod bmp;
@@ -36,4 +39,20 @@ pub enum AllowDangerous
 {
     Never,
     Really
+}
+
+impl ValueEnum for AllowDangerous
+{
+    fn value_variants<'a>() -> &'a [Self]
+    {
+        &[Self::Never, Self::Really]
+    }
+
+    fn to_possible_value(&self) -> Option<PossibleValue>
+    {
+        match self {
+            Self::Never => Some("never".into()),
+            Self::Really => Some("really".into()),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,11 @@ pub mod elf;
 pub mod firmware_selector;
 pub mod flasher;
 pub mod metadata;
+pub mod probe_identity;
 pub mod switcher;
 pub mod usb;
 #[cfg(windows)]
 pub mod windows;
-pub mod probe_identity;
 
 pub trait BmpParams
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@
 // SPDX-FileContributor: Written by Piotr Esden-Tempski <piotr@esden.net>
 // SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 
+use crate::bmp::FirmwareType;
+
 pub mod bmp;
 pub mod docs_viewer;
 pub mod error;
@@ -17,3 +19,21 @@ pub mod usb;
 pub mod windows;
 pub mod probe_identity;
 
+pub trait BmpParams
+{
+    fn index(&self) -> Option<usize>;
+    fn serial_number(&self) -> Option<&str>;
+    fn allow_dangerous_options(&self) -> AllowDangerous;
+}
+
+pub trait FlashParams
+{
+    fn override_firmware_type(&self) -> Option<FirmwareType>;
+}
+
+#[derive(Clone, Copy)]
+pub enum AllowDangerous
+{
+    Never,
+    Really
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,11 +26,11 @@ pub trait BmpParams
 {
     fn index(&self) -> Option<usize>;
     fn serial_number(&self) -> Option<&str>;
-    fn allow_dangerous_options(&self) -> AllowDangerous;
 }
 
 pub trait FlashParams
 {
+    fn allow_dangerous_options(&self) -> AllowDangerous;
     fn override_firmware_type(&self) -> Option<FirmwareType>;
 }
 

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -177,6 +177,24 @@ impl TryFrom<String> for ProbeIdentity
     }
 }
 
+impl Display for ProbeIdentity
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result
+    {
+        // Probe names always use the product string as a prefix
+        write!(f, "{}", BMP_PRODUCT_STRING)?;
+        // If it's not a native probe, display the variant name
+        if self.probe != Probe::Native {
+            write!(f, " ({})", self.probe.to_string())?;
+        }
+        // Translate the version string as best as possible to a readable form
+        match &self.version {
+            Version::Unknown => write!(f, " <invalid version>"),
+            Version::Known(version) => write!(f, " {}", version),
+        }
+    }
+}
+
 impl ProbeIdentity
 {
     pub fn variant(&self) -> Probe

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -122,19 +122,18 @@ fn parse_version_from_identity_string(input: &str) -> Result<&str, ParseVersionE
     Ok(version)
 }
 
-impl TryFrom<String> for ProbeIdentity
+impl TryFrom<&str> for ProbeIdentity
 {
     type Error = Report;
 
-    // BMD product strings are in one of the following forms:
-    // Recent: Black Magic Probe v2.0.0-rc2
-    //       : Black Magic Probe (ST-Link v2) v1.10.0-1273-g2b1ce9aee
-    //       : Black Magic Probe v2.0.0-rc2-65-g221c3031f
-    //    Old: Black Magic Probe
-
-    fn try_from(value: String) -> Result<Self>
+    fn try_from(identity: &str) -> Result<Self>
     {
-        let identity = value;
+        // BMD product strings are in one of the following forms:
+        // Recent: Black Magic Probe v2.0.0-rc2
+        //       : Black Magic Probe (ST-Link/v2) v1.10.0-1273-g2b1ce9aee
+        //    Old: Black Magic Probe
+        // From this we want to extract two main things: version (if available), and probe variety
+        // (probe variety meaning alternative platform kind if not a BMP itself)
 
         // Every identity should start with 'Black Magic Probe'
         if !identity.starts_with(BMP_PRODUCT_STRING) {
@@ -161,6 +160,16 @@ impl TryFrom<String> for ProbeIdentity
             probe,
             version: version.into()
         })
+    }
+}
+
+impl TryFrom<String> for ProbeIdentity
+{
+    type Error = Report;
+
+    fn try_from(identity: String) -> Result<Self>
+    {
+        identity.as_str().try_into()
     }
 }
 

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -269,6 +269,19 @@ impl From<String> for VersionNumber
     }
 }
 
+impl ToString for VersionNumber
+{
+    fn to_string(&self) -> String
+    {
+        match self {
+            Self::Unknown => "".into(),
+            Self::Invalid => "<invalid version>".into(),
+            Self::GitHash(git_hash) => git_hash.clone(),
+            Self::FullVersion(version_parts) => version_parts.to_string()
+        }
+    }
+}
+
 impl PartialOrd for VersionNumber
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering>

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -34,17 +34,6 @@ enum ParseNameError
     FoundNotMatchedParenthesis
 }
 
-impl Display for ParseNameError
-{
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result
-    {
-        match self {
-            ParseNameError::OpeningParenthesisAfterClosingParenthesis => write!(f, "A '(' parenthesis is found after a ')'."),
-            ParseNameError::FoundNotMatchedParenthesis => write!(f, "Not a matching pair of parenthesis found."),
-        }
-    }
-}
-
 #[derive(Debug)]
 enum ParseVersionError
 {
@@ -92,6 +81,17 @@ struct GitVersion<'a>
     release_candidate: Option<usize>,
     commits: usize,
     hash: &'a str,
+}
+
+impl Display for ParseNameError
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result
+    {
+        match self {
+            ParseNameError::OpeningParenthesisAfterClosingParenthesis => write!(f, "A '(' parenthesis is found after a ')'."),
+            ParseNameError::FoundNotMatchedParenthesis => write!(f, "Not a matching pair of parenthesis found."),
+        }
+    }
 }
 
 impl Display for ParseVersionError

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -1,3 +1,8 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+// SPDX-FileContributor: Modified by P-Storm <pauldeman@gmail.com>
+
 use std::fmt::{Display, Formatter};
 use color_eyre::eyre::{eyre, Result};
 use color_eyre::Report;
@@ -87,7 +92,7 @@ fn parse_version_from_identity_string(input: &str) -> Result<Version, ParseVersi
     if !version.starts_with('v') {
         return Err(ParseVersionError::NotStartingWithV(version));
     }
-    
+
     if version.trim().is_empty() {
         return Err(ParseVersionError::EmptyOrWhitespaceVersion);
     }

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -266,15 +266,15 @@ impl From<String> for VersionNumber
     }
 }
 
-impl ToString for VersionNumber
+impl Display for VersionNumber
 {
-    fn to_string(&self) -> String
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result
     {
-        match self {
-            Self::Unknown => "".into(),
-            Self::Invalid => "<invalid version>".into(),
-            Self::GitHash(git_hash) => git_hash.clone(),
-            Self::FullVersion(version_parts) => version_parts.to_string()
+        match &self {
+            VersionNumber::Unknown => write!(f, "<unknown>"),
+            VersionNumber::Invalid => write!(f, "<invalid version>"),
+            VersionNumber::GitHash(hash) => write!(f, "{}", hash),
+            VersionNumber::FullVersion(version_parts) => write!(f, "{}", version_parts.to_string()),
         }
     }
 }

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -45,6 +45,7 @@ enum ParseVersionError
 #[derive(PartialEq, Eq, Ord)]
 pub enum VersionNumber
 {
+    Unknown,
     Invalid,
     GitHash(String),
     FullVersion(VersionParts),
@@ -274,6 +275,7 @@ impl PartialOrd for VersionNumber
     {
         // There's no ordering invalid version numbers, or Git hash only ones beyond equality
         match self {
+            Self::Unknown => None,
             Self::Invalid => None,
             Self::GitHash(lhs) => {
                 match other {
@@ -293,7 +295,7 @@ impl PartialOrd for VersionNumber
                 // If we're a full version though then if the RHS is also a full version, apply full
                 // partial comparison - everything else cannot be ordered however.
                 match other {
-                    Self::Invalid | Self::GitHash(_) => None,
+                    Self::Unknown | Self::Invalid | Self::GitHash(_) => None,
                     Self::FullVersion(rhs) => lhs.partial_cmp(rhs),
                 }
             }

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -34,7 +34,7 @@ enum ParseVersionError
     EmptyOrWhitespaceVersion,
 }
 
-#[derive(PartialEq, Eq, Ord)]
+#[derive(Debug, PartialEq, Eq, Ord)]
 pub enum VersionNumber
 {
     Unknown,
@@ -43,7 +43,7 @@ pub enum VersionNumber
     FullVersion(VersionParts),
 }
 
-#[derive(PartialEq, Eq, Ord)]
+#[derive(Debug, PartialEq, Eq, Ord)]
 pub struct VersionParts
 {
     major: usize,
@@ -53,16 +53,16 @@ pub struct VersionParts
     dirty: bool,
 }
 
-#[derive(PartialEq, Eq, Ord)]
-enum VersionKind
+#[derive(Debug, PartialEq, Eq, Ord)]
+pub enum VersionKind
 {
     Release,
     ReleaseCandidate(usize),
     Development(GitVersion),
 }
 
-#[derive(PartialEq, Eq, Ord)]
-struct GitVersion
+#[derive(Debug, PartialEq, Eq, Ord)]
+pub struct GitVersion
 {
     release_candidate: Option<usize>,
     commits: usize,

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -313,6 +313,14 @@ impl PartialOrd for VersionNumber
     }
 }
 
+impl VersionParts
+{
+    pub fn from_parts(major: usize, minor: usize, revision: usize, kind: VersionKind, dirty: bool) -> Self
+    {
+        Self { major, minor, revision, kind, dirty }
+    }
+}
+
 impl TryFrom<&str> for VersionParts
 {
     type Error = Report;
@@ -518,6 +526,14 @@ impl PartialOrd for VersionKind
                 }
             }
         }
+    }
+}
+
+impl GitVersion
+{
+    pub fn from_parts(release_candidate: Option<usize>, commits: usize, hash: String) -> Self
+    {
+        Self { release_candidate, commits, hash }
     }
 }
 

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -382,6 +382,22 @@ impl TryFrom<&str> for VersionParts
     }
 }
 
+impl ToString for VersionParts
+{
+    fn to_string(&self) -> String
+    {
+        // Build out the base version string
+        let mut version = format!("{}.{}.{}", self.major, self.minor, self.revision);
+        // Now flatten out the kind value
+        version += &self.kind.to_string();
+        // And finally, if the version represents a dirty build, add that before we return
+        if self.dirty {
+            version += "-dirty";
+        }
+        version
+    }
+}
+
 impl PartialOrd for VersionParts
 {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering>
@@ -428,6 +444,18 @@ impl PartialOrd for VersionParts
     }
 }
 
+impl ToString for VersionKind
+{
+    fn to_string(&self) -> String
+    {
+        match self {
+            Self::Release => "".into(),
+            Self::ReleaseCandidate(rc_number) => format!("-rc{}", rc_number),
+            Self::Development(git_version) => git_version.to_string(),
+        }
+    }
+}
+
 impl PartialOrd for VersionKind
 {
     /// NB: These orderings are only true IFF we are comparing the same base versions in VersionParts.
@@ -460,6 +488,19 @@ impl PartialOrd for VersionKind
                 }
             }
         }
+    }
+}
+
+impl ToString for GitVersion
+{
+    fn to_string(&self) -> String
+    {
+        let base_version = match self.release_candidate {
+            None => "".into(),
+            Some(rc_number) => format!("-rc{}", rc_number),
+        };
+        let git_version = format!("-{}-{}", self.commits, self.hash);
+        base_version + &git_version
     }
 }
 

--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -114,8 +114,7 @@ where
     }
 }
 
-fn pick_release(metadata: &Metadata, identity: ProbeIdentity) ->
-    Result<Option<(&str, &Firmware)>>
+fn pick_release(metadata: &Metadata, identity: ProbeIdentity) -> Result<Option<(&str, &Firmware)>>
 {
     let variant = &identity.variant();
     let firmware_version = match &identity.version {

--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -37,14 +37,9 @@ where
         }
     };
 
-    let firmware_identity_string = probe.firmware_identity()?;
-    println!("Probe {} ({}) selected for firmware update", firmware_identity_string, probe.serial_number()?);
-
     // Now extract the probe's identification, and check it's valid
-    let identity: ProbeIdentity = firmware_identity_string.try_into().map_err(|err| {
-        println!("Couldn't extract an identity from firmware descriptor string: {}", err);
-        eyre!("Couldn't extract an identity from firmware descriptor string")
-    })?;
+    let identity = probe.firmware_identity()?;
+    println!("Probe {} ({}) selected for firmware update", identity, probe.serial_number()?);
 
     // Figure out where the firmware and metadata cache is
     let cache = paths.cache_dir();

--- a/src/switcher.rs
+++ b/src/switcher.rs
@@ -157,7 +157,7 @@ fn pick_release(metadata: &Metadata, identity: ProbeIdentity) -> Result<Option<(
     Ok(Some((items[selection].as_str(), &metadata.releases[items[selection].as_str()].firmware[&variant])))
 }
 
-fn pick_firmware<'a>(release: &'a str, firmware: &'a Firmware) -> Result<Option<&'a FirmwareDownload>>
+pub fn pick_firmware<'a>(release: &'a str, firmware: &'a Firmware) -> Result<Option<&'a FirmwareDownload>>
 {
     match firmware.variants.len() {
         // If there are now firmware variants for this release, that's an error
@@ -180,7 +180,7 @@ fn pick_firmware<'a>(release: &'a str, firmware: &'a Firmware) -> Result<Option<
     }
 }
 
-fn download_firmware(variant: &FirmwareDownload, cache_path: &Path) -> Result<PathBuf>
+pub fn download_firmware(variant: &FirmwareDownload, cache_path: &Path) -> Result<PathBuf>
 {
     // Ensure the cache directory exists
     fs::create_dir_all(cache_path)?;

--- a/tests/probe_identity.rs
+++ b/tests/probe_identity.rs
@@ -1,16 +1,24 @@
+// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
+// SPDX-FileContributor: Written by P-Storm <pauldeman@gmail.com>
+// SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
+
 #[cfg(test)]
-mod tests {
+mod tests
+{
     use color_eyre::eyre::Result;
     use bmputil::metadata::structs::Probe;
-    use bmputil::probe_identity::{ProbeIdentity, Version};
-    
+    use bmputil::probe_identity::{GitVersion, ProbeIdentity, VersionKind, VersionNumber, VersionParts};
+
     #[test]
     fn extract_native() -> Result<()>
     {
-        let res: ProbeIdentity = String::from("Black Magic Probe v2.0.0-rc2").try_into()?            ;
+        let res: ProbeIdentity = "Black Magic Probe v2.0.0-rc2".try_into()?;
 
         assert_eq!(res.variant(), Probe::Native);
-        assert_eq!(res.version, Version::Known(String::from("v2.0.0-rc2")));
+        assert_eq!(res.version, VersionNumber::FullVersion(VersionParts {
+            major: 2, minor: 0, revision: 0, kind: VersionKind::ReleaseCandidate(2), dirty: false
+        }));
         Ok(())
     }
 
@@ -20,7 +28,7 @@ mod tests {
         let res: ProbeIdentity = String::from("Black Magic Probe").try_into()?;
 
         assert_eq!(res.variant(), Probe::Native);
-        assert_eq!(res.version, Version::Unknown);
+        assert_eq!(res.version, VersionNumber::Unknown);
         Ok(())
     }
 
@@ -30,12 +38,16 @@ mod tests {
         let res: ProbeIdentity = String::from("Black Magic Probe v2.0.0-rc2-65-g221c3031f").try_into()?;
 
         assert_eq!(res.variant(), Probe::Native);
-        assert_eq!(res.version, Version::Known(String::from("v2.0.0-rc2-65-g221c3031f")));
+        assert_eq!(res.version, VersionNumber::FullVersion(VersionParts {
+            major: 2, minor: 0, revision: 0, kind: VersionKind::Development(GitVersion {
+                release_candidate: Some(2), 65, "g221c3031f"
+            }), dirty: false
+        }));
         Ok(())
     }
 
     #[test]
-    fn extract_version_only_hash_error()
+    fn extract_version_only_hash()
     {
         let result: Result<ProbeIdentity> = String::from("Black Magic Probe g221c3031f").try_into();
 
@@ -51,7 +63,11 @@ mod tests {
         let res: ProbeIdentity = String::from("Black Magic Probe (ST-Link/v2) v1.10.0-1273-g2b1ce9aee").try_into()?;
 
         assert_eq!(res.variant(), Probe::Stlink);
-        assert_eq!(res.version, Version::Known(String::from("v1.10.0-1273-g2b1ce9aee")));
+        assert_eq!(res.version, VersionNumber::FullVersion(VersionParts {
+            major: 1, minor: 10, revision: 0, kind: VersionKind::Development(GitVersion {
+                release_candidate: Noone, 1273, "g2b1ce9aee"
+            }), dirty: false
+        }));
         Ok(())
     }
 

--- a/tests/probe_identity.rs
+++ b/tests/probe_identity.rs
@@ -13,68 +13,71 @@ mod tests
     #[test]
     fn extract_native() -> Result<()>
     {
-        let res: ProbeIdentity = "Black Magic Probe v2.0.0-rc2".try_into()?;
+        let result: ProbeIdentity = "Black Magic Probe v2.0.0-rc2".try_into()?;
 
-        assert_eq!(res.variant(), Probe::Native);
-        assert_eq!(res.version, VersionNumber::FullVersion(VersionParts {
-            major: 2, minor: 0, revision: 0, kind: VersionKind::ReleaseCandidate(2), dirty: false
-        }));
+        assert_eq!(result.variant(), Probe::Native);
+        assert_eq!(result.version, VersionNumber::FullVersion(
+            VersionParts::from_parts(2, 0, 0, VersionKind::ReleaseCandidate(2), false)
+        ));
         Ok(())
     }
 
     #[test]
     fn extract_old() -> Result<()>
     {
-        let res: ProbeIdentity = String::from("Black Magic Probe").try_into()?;
+        let result: ProbeIdentity = "Black Magic Probe".try_into()?;
 
-        assert_eq!(res.variant(), Probe::Native);
-        assert_eq!(res.version, VersionNumber::Unknown);
+        assert_eq!(result.variant(), Probe::Native);
+        assert_eq!(result.version, VersionNumber::Unknown);
         Ok(())
     }
 
     #[test]
     fn extract_without_parathesis() -> Result<()>
     {
-        let res: ProbeIdentity = String::from("Black Magic Probe v2.0.0-rc2-65-g221c3031f").try_into()?;
+        let result: ProbeIdentity = "Black Magic Probe v2.0.0-rc2-65-g221c3031f".try_into()?;
 
-        assert_eq!(res.variant(), Probe::Native);
-        assert_eq!(res.version, VersionNumber::FullVersion(VersionParts {
-            major: 2, minor: 0, revision: 0, kind: VersionKind::Development(GitVersion {
-                release_candidate: Some(2), 65, "g221c3031f"
-            }), dirty: false
-        }));
+        assert_eq!(result.variant(), Probe::Native);
+        assert_eq!(result.version, VersionNumber::FullVersion(
+            VersionParts::from_parts(
+                2, 0, 0, VersionKind::Development(
+                    GitVersion::from_parts(Some(2), 65, "g221c3031f".into())
+                ), false
+            )
+        ));
         Ok(())
     }
 
     #[test]
-    fn extract_version_only_hash()
+    fn extract_version_only_hash() -> Result<()>
     {
-        let result: Result<ProbeIdentity> = String::from("Black Magic Probe g221c3031f").try_into();
+        let result: ProbeIdentity = "Black Magic Probe g221c3031f".try_into()?;
 
-        assert!(result.is_err());
-        if let Err(err) = result {
-            assert_eq!(err.to_string(), "Error while parsing version string: Version doesn't start with v, got 'g221c3031f'");
-        }
+        assert_eq!(result.variant(), Probe::Native);
+        assert_eq!(result.version, VersionNumber::GitHash("221c3031f".into()));
+        Ok(())
     }
 
     #[test]
     fn extract_st_link() -> Result<()>
     {
-        let res: ProbeIdentity = String::from("Black Magic Probe (ST-Link/v2) v1.10.0-1273-g2b1ce9aee").try_into()?;
+        let result: ProbeIdentity = "Black Magic Probe (ST-Link/v2) v1.10.0-1273-g2b1ce9aee".try_into()?;
 
-        assert_eq!(res.variant(), Probe::Stlink);
-        assert_eq!(res.version, VersionNumber::FullVersion(VersionParts {
-            major: 1, minor: 10, revision: 0, kind: VersionKind::Development(GitVersion {
-                release_candidate: Noone, 1273, "g2b1ce9aee"
-            }), dirty: false
-        }));
+        assert_eq!(result.variant(), Probe::Stlink);
+        assert_eq!(result.version, VersionNumber::FullVersion(
+            VersionParts::from_parts(
+                1, 10, 0, VersionKind::Development(
+                    GitVersion::from_parts(None, 1273, "g2b1ce9aee".into())
+                ), false
+            )
+        ));
         Ok(())
     }
 
     #[test]
     fn extract_without_closing()
     {
-        let result: Result<ProbeIdentity> = "Black Magic Probe (ST-Link".to_string().try_into();
+        let result: Result<ProbeIdentity> = "Black Magic Probe (ST-Link".try_into();
 
         assert!(result.is_err());
         if let Err(err) = result {
@@ -85,7 +88,7 @@ mod tests
     #[test]
     fn unknown()
     {
-        let result: Result<ProbeIdentity> = String::from("Something (v1.2.3)").try_into();
+        let result: Result<ProbeIdentity> = "Something (v1.2.3)".try_into();
 
         assert!(result.is_err());
         if let Err(err) = result {


### PR DESCRIPTION
In this PR we first convert the CLI from a text-based old style Clap parser, to clap-derive based structures. We then restructure the interface per the internal notes to provide a more consistent command line experience and make space for future tool functionality.

This PR introduces full parsing for version numbers from the firmware and metadata, allowing them to be properly and accurately compared. This allows the tool to determine if the probe is running the most up-to-date release firmware or not automatically and upgrade the probe accordingly via `bmputil-cli probe update`. This also fixes a long standing bug in the post-Flash validation step which caused havoc if the programming process actually failed and the tool didn't realise.

There is a known issue that was introduced with #36 where if bootloaders other than the project bootloader are used, the version number handler is too strict and makes the tool not play with those. This will be fixed in a follow-up PR.

This PR does not yet implement the guts of `bmputil-cli probe info --list-targets`, and this will be fixed (fixing the resultant warning) in a follow-up PR that introduces handling for the remote serial protocol for the probe.