### PR TITLE
Feature: Better update control

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "byteorder"
@@ -1534,9 +1534,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -1949,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "owo-colors"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "parking_lot"
@@ -3840,9 +3840,9 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -117,6 +117,10 @@ struct UpdateArguments
 	/// Force the current latest release onto the probe even if the probe is running ostensibly newer firmware
 	force: bool,
 
+	#[arg(long = "use-rc", default_value_t = false)]
+	/// Allow the tool to use release candidates as possible upgrade targets when considering the latest release
+	use_rc: bool,
+
 	#[command(subcommand)]
 	subcommand: Option<UpdateCommands>,
 }
@@ -276,7 +280,7 @@ fn update_probe(cli_args: &CliArguments, flash_args: &UpdateArguments, paths: &P
 			let metadata = download_metadata(cache)?;
 			// Extract the most recent release from the metadata
 			let (latest_version, latest_release) = metadata
-				.latest()
+				.latest(flash_args.use_rc)
 				.ok_or_eyre("Could not determine the latest release of the firmware")?;
 			// Extract the matching firmware for the probe
 			let latest_firmware = latest_release.firmware.get(&identity.variant());

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -113,6 +113,10 @@ struct UpdateArguments
 	/// Forcibly override firmware type autodetection and Flash anyway (may result in an unbootable device!)
 	force_override_flash: bool,
 
+	#[arg(short = 'f', long = "force", default_value_t = false)]
+	/// Force the current latest release onto the probe even if the probe is running ostensibly newer firmware
+	force: bool,
+
 	#[command(subcommand)]
 	subcommand: Option<UpdateCommands>,
 }
@@ -285,8 +289,9 @@ fn update_probe(cli_args: &CliArguments, flash_args: &UpdateArguments, paths: &P
 			};
 
 			// Check whether the release is newer than the firmware on the probe, and if it is, pick that as the file.
-			// If it is not, print a message and exit successfully.
-			if identity.version >= latest_version {
+			// If it is not, print a message and exit successfully. This check is bypassed when `--force` is given
+			// which makes this command push the selected firmware to the probe anyway
+			if identity.version >= latest_version && !flash_args.force {
 				info!(
 					"Latest release {} is not newer than firmware version {}, not updating",
 					latest_version, identity.version

--- a/src/metadata/structs.rs
+++ b/src/metadata/structs.rs
@@ -329,7 +329,7 @@ impl<'de> Visitor<'de> for TargetArchVisitor
 
 impl Metadata
 {
-	pub fn latest(&self) -> Option<(VersionNumber, &Release)>
+	pub fn latest(&self, include_rcs: bool) -> Option<(VersionNumber, &Release)>
 	{
 		let mut current_release = None;
 
@@ -337,7 +337,7 @@ impl Metadata
 		// latest stable release (not pre-release)
 		for (version, release) in &self.releases {
 			// Check if the version is pre-release, and if so.. ignore it
-			if version.contains("-rc") {
+			if version.contains("-rc") && !include_rcs {
 				continue;
 			}
 			// Otherwise, turn it into a version string and compare


### PR DESCRIPTION
In this PR we introduce two new options (`--force` and `--use-rc`) to allow a user to specify that when trying to update their probe firmware, they either:
* want the update forced regardless of version checks (`--force`) or
* want to consider release candidates when selecting potential updates to attempt (`--use-rc`)

This provides a nice automated way to roll probes back to known latest releases, and choose to use pre-release versions from the metadata index.