### PR TITLE
Fix: Bootloader product string parsing

### DIFF
--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -241,6 +241,11 @@ impl ProbeIdentity
 			_ => None,
 		}
 	}
+
+	pub fn is_bootloader(&self) -> bool
+	{
+		matches!(self.kind, DeviceKind::Bootloader(_))
+	}
 }
 
 impl TryFrom<String> for Probe

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -140,6 +140,16 @@ impl TryFrom<&str> for ProbeIdentity
 		//    Old: Black Magic Probe
 		// From this we want to extract two main things: version (if available), and probe variety
 		// (probe variety meaning alternative platform kind if not a BMP itself)
+		//
+		// NB: Bootloaders do not necessarily follow this pattern and can use other string formats.
+		// They are no less valid(!) and must be represented somehow by a ProbeIdentity.
+		// Examples from the wild include:
+		// - Black Magic Probe DFU v1.9.0
+		// - dragonBoot DFU bootloader
+		// and ST's boot ROM bootloader
+		//
+		// We mark these additional strings as bootloader strings for which we cannot determine the
+		// probe kind that they run on as the strings fail to encode that information.
 
 		// Every identity should start with 'Black Magic Probe'
 		if !identity.starts_with(BMP_PRODUCT_STRING) {

--- a/src/probe_identity.rs
+++ b/src/probe_identity.rs
@@ -166,14 +166,15 @@ impl TryFrom<&str> for ProbeIdentity
 
 		// Removes the first length from the identity, because we know it starts with the 'Black Magic Probe'
 		let parse_slice = &identity[BMP_PRODUCT_STRING_LENGTH..];
-		let probe_result = parse_name_from_identity_string(parse_slice);
-		let probe_string = probe_result.map_err(|error| eyre!("Error while parsing probe string: {}", error))?;
-		let probe = probe_string.to_lowercase().try_into()?;
+		let probe = parse_name_from_identity_string(parse_slice)
+			.map_err(|error| eyre!("Error while parsing probe string: {}", error))?
+			.to_lowercase();
 
-		let version_result = parse_version_from_identity_string(parse_slice);
-		let version = version_result.map_err(|error| eyre!("Error while parsing version string: {}", error))?;
+		let version = parse_version_from_identity_string(parse_slice)
+			.map_err(|error| eyre!("Error while parsing version string: {}", error))?;
+
 		Ok(ProbeIdentity {
-			probe,
+			probe: probe.try_into()?,
 			version: version.into(),
 		})
 	}

--- a/tests/probe_identity.rs
+++ b/tests/probe_identity.rs
@@ -96,6 +96,23 @@ mod tests
 	}
 
 	#[test]
+	fn extract_bootloader() -> Result<()>
+	{
+		let result: ProbeIdentity = "Black Magic Probe DFU v1.8.0".try_into()?;
+
+		assert_eq!(result.variant(), None);
+		assert_eq!(result.version, VersionNumber::Unknown);
+		assert!(result.is_bootloader());
+
+		let result: ProbeIdentity = "dragonBoot DFU bootloader".try_into()?;
+
+		assert_eq!(result.variant(), None);
+		assert_eq!(result.version, VersionNumber::Unknown);
+		assert!(result.is_bootloader());
+		Ok(())
+	}
+
+	#[test]
 	fn unknown()
 	{
 		let result: Result<ProbeIdentity> = "Something (v1.2.3)".try_into();

--- a/tests/probe_identity.rs
+++ b/tests/probe_identity.rs
@@ -15,7 +15,7 @@ mod tests
 	{
 		let result: ProbeIdentity = "Black Magic Probe v2.0.0-rc2".try_into()?;
 
-		assert_eq!(result.variant(), Probe::Native);
+		assert_eq!(result.variant(), Some(Probe::Native));
 		assert_eq!(
 			result.version,
 			VersionNumber::FullVersion(VersionParts::from_parts(2, 0, 0, VersionKind::ReleaseCandidate(2), false))
@@ -28,7 +28,7 @@ mod tests
 	{
 		let result: ProbeIdentity = "Black Magic Probe".try_into()?;
 
-		assert_eq!(result.variant(), Probe::Native);
+		assert_eq!(result.variant(), Some(Probe::Native));
 		assert_eq!(result.version, VersionNumber::Unknown);
 		Ok(())
 	}
@@ -38,7 +38,7 @@ mod tests
 	{
 		let result: ProbeIdentity = "Black Magic Probe v2.0.0-rc2-65-g221c3031f".try_into()?;
 
-		assert_eq!(result.variant(), Probe::Native);
+		assert_eq!(result.variant(), Some(Probe::Native));
 		assert_eq!(
 			result.version,
 			VersionNumber::FullVersion(VersionParts::from_parts(
@@ -57,7 +57,7 @@ mod tests
 	{
 		let result: ProbeIdentity = "Black Magic Probe g221c3031f".try_into()?;
 
-		assert_eq!(result.variant(), Probe::Native);
+		assert_eq!(result.variant(), Some(Probe::Native));
 		assert_eq!(result.version, VersionNumber::GitHash("221c3031f".into()));
 		Ok(())
 	}
@@ -67,7 +67,7 @@ mod tests
 	{
 		let result: ProbeIdentity = "Black Magic Probe (ST-Link/v2) v1.10.0-1273-g2b1ce9aee".try_into()?;
 
-		assert_eq!(result.variant(), Probe::Stlink);
+		assert_eq!(result.variant(), Some(Probe::Stlink));
 		assert_eq!(
 			result.version,
 			VersionNumber::FullVersion(VersionParts::from_parts(


### PR DESCRIPTION
In this PR we solve the problems with handling bootloader identities that #36 highlighted was not well dealt with or clear to understand.

This was triggered by finding that commands such as `probe reboot` would not find the probe in its bootloader after the first phase of restarting the probe was complete. This was a direct consequence of the ProbeIdentity code considering the bootloader product string to be invalid and throwing a fit. The fix in this PR is not comprehensive, but it should serve as a solid extendable base.

With this, all previously working bootloaders for the native probe work properly again save for a second bug found in the DFU reboot handling for going from bootloader back to firmware for non-DfuSe bootloaders.