### PR TITLE
CLI Feature: target power 

### DIFF
--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -447,7 +447,7 @@ fn power_command(cli_args: &CliArguments) -> Result<()>
 
 	let power = remote.get_target_power_state()?;
 
-    info!("Device target power state: {}", power);
+	info!("Device target power state: {}", power);
 
 	Ok(())
 }

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: 2022-2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
-// SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
+// SPDX-FileContributor: Modified by P-Storm <pauldeman@gmail.com>
 
 use std::ffi::OsStr;
 use std::io::stdout;
@@ -451,7 +451,7 @@ fn power_command(cli_args: &CliArguments) -> Result<()>
 
 	let power = remote.get_target_power_state()?;
 
-	println!("Device target power state: {}", power);
+    info!("Device target power state: {}", power);
 
 	Ok(())
 }

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: 2022-2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Mikaela Szekely <mikaela.szekely@qyriad.me>
+// SPDX-FileContributor: Modified by Rachel Mant <git@dragonmux.network>
 // SPDX-FileContributor: Modified by P-Storm <pauldeman@gmail.com>
 
 use std::ffi::OsStr;
@@ -81,11 +82,6 @@ struct ProbeArguments
 #[derive(Args)]
 struct TargetArguments
 {
-	#[arg(global = true, long = "allow-dangerous-options", hide = true, default_value_t = AllowDangerous::Never)]
-	#[arg(value_enum)]
-	/// Allow usage of advanced, dangerous options that can result in unbootable devices (use with heavy caution!)
-	allow_dangerous_options: AllowDangerous,
-
 	#[command(subcommand)]
 	subcommand: TargetCommmands,
 }
@@ -94,7 +90,7 @@ struct TargetArguments
 #[command(arg_required_else_help(true))]
 enum TargetCommmands
 {
-	/// Print information about the target powered Command
+	/// Print information about the target power control state
 	Power,
 }
 
@@ -682,7 +678,7 @@ fn main() -> Result<()>
 				Ok(())
 			},
 		},
-		ToplevelCommmands::Target(target_args) => match &target_args.subcommand {
+		ToplevelCommmands::Target(target_command) => match target_command.subcommand {
 			TargetCommmands::Power => power_command(&cli_args),
 		},
 		ToplevelCommmands::Server => {

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -58,7 +58,8 @@ enum ToplevelCommmands
 	/// Actions to be performed against a probe
 	Probe(ProbeArguments),
 	/// Actions to be performed against a target connected to a probe
-	Target(TargetArguments),
+	#[command(subcommand)]
+	Target(TargetCommmands),
 	/// Actions that run the tool as a debug/tracing server
 	Server,
 	/// Actions that run debugging commands against a target connected to a probe
@@ -77,13 +78,6 @@ struct ProbeArguments
 
 	#[command(subcommand)]
 	subcommand: ProbeCommmands,
-}
-
-#[derive(Args)]
-struct TargetArguments
-{
-	#[command(subcommand)]
-	subcommand: TargetCommmands,
 }
 
 #[derive(Subcommand)]
@@ -678,7 +672,7 @@ fn main() -> Result<()>
 				Ok(())
 			},
 		},
-		ToplevelCommmands::Target(target_command) => match target_command.subcommand {
+		ToplevelCommmands::Target(command) => match command {
 			TargetCommmands::Power => power_command(&cli_args),
 		},
 		ToplevelCommmands::Server => {

--- a/src/bmp_matcher.rs
+++ b/src/bmp_matcher.rs
@@ -134,7 +134,10 @@ impl BmpMatcher
 	fn matching_probe(&self, index: usize, device_info: DeviceInfo) -> MatchResult
 	{
 		// Consider the serial to match if it equals that of the device or if one was not specified at all.
-		let serial_matches = self.serial.as_deref().is_none_or(|s| Some(s) == device_info.serial_number());
+		let serial_matches = self
+			.serial
+			.as_deref()
+			.is_none_or(|s| Some(s) == device_info.serial_number());
 
 		// Consider the index to match if it equals that of the device or if one was not specified at all.
 		let index_matches = self.index.is_none_or(|needle| needle == index);
@@ -168,7 +171,8 @@ pub struct BmpMatchResults
 
 impl FromIterator<MatchResult> for BmpMatchResults
 {
-	/// This implements the internals of .collect() on an iterator to convert the iterator MatchResult into a BmpMatchResults
+	/// This implements the internals of .collect() on an iterator to convert the iterator MatchResult into a
+	/// BmpMatchResults
 	fn from_iter<I: IntoIterator<Item = MatchResult>>(iter: I) -> Self
 	{
 		let mut results = BmpMatchResults {
@@ -200,7 +204,11 @@ impl BmpMatchResults
 				match self.filtered_out.len() {
 					0 => {},
 					1 => {
-						match BmpDevice::from_usb_device(self.filtered_out.pop().expect("The length check makes this a guaranteed assumption")) {
+						match BmpDevice::from_usb_device(
+							self.filtered_out
+								.pop()
+								.expect("The length check makes this a guaranteed assumption"),
+						) {
 							Ok(bmpdev) => warn!(
 								"Matching device not found, but and the following Black Magic Probe device was \
 								 filtered out: {}",

--- a/src/metadata/firmware_download.rs
+++ b/src/metadata/firmware_download.rs
@@ -32,7 +32,11 @@ impl FirmwareDownload
 		if docs_path.extension() == Some(checked_extension) {
 			docs_path.set_extension("md");
 		} else {
-			return Err(eyre!("Path extension is not of '{:?}', got '{:?}'", checked_extension, docs_path.extension()));
+			return Err(eyre!(
+				"Path extension is not of '{:?}', got '{:?}'",
+				checked_extension,
+				docs_path.extension()
+			));
 		}
 
 		// Copy only the origin
@@ -114,7 +118,10 @@ mod tests
 		let variant = FirmwareDownload {
 			friendly_name: "Black Magic Debug for BMP (full)".into(),
 			file_name: PathBuf::from("blackmagic-native-full-v1.10.0.elf"),
-			uri: Url::parse("https://github.com/blackmagic-debug/blackmagic/releases/v1.10.0/blackmagic-native-v1_10_0.elf").expect("Setup url shouldn't fail"),
+			uri: Url::parse(
+				"https://github.com/blackmagic-debug/blackmagic/releases/v1.10.0/blackmagic-native-v1_10_0.elf",
+			)
+			.expect("Setup url shouldn't fail"),
 		};
 
 		let res = variant.build_release_uri("error");

--- a/src/serial/remote/mod.rs
+++ b/src/serial/remote/mod.rs
@@ -111,6 +111,7 @@ pub trait BmdRemoteProtocol
 	fn target_clk_output_enable(&self, enable: bool);
 	fn supported_architectures(&self) -> Result<Option<TargetArchitecture>>;
 	fn supported_families(&self) -> Result<Option<TargetFamily>>;
+	fn get_target_power_state(&self) -> Result<bool>;
 }
 
 /// Types implementing this trait provide raw SWD access to targets over the BMD remote protocol

--- a/src/serial/remote/protocol_v0.rs
+++ b/src/serial/remote/protocol_v0.rs
@@ -9,10 +9,7 @@ use log::{debug, warn};
 
 use crate::serial::bmd_rsp::BmdRspInterface;
 use crate::serial::remote::adi::{AdiV5AccessPort, AdiV5DebugPort};
-use crate::serial::remote::{
-	Align, BmdAdiV5Protocol, BmdJtagProtocol, BmdRemoteProtocol, BmdRiscvProtocol, BmdSwdProtocol, JtagDev,
-	REMOTE_RESP_ERR, TargetAddr64, TargetArchitecture, TargetFamily,
-};
+use crate::serial::remote::{Align, BmdAdiV5Protocol, BmdJtagProtocol, BmdRemoteProtocol, BmdRiscvProtocol, BmdSwdProtocol, JtagDev, REMOTE_RESP_ERR, TargetAddr64, TargetArchitecture, TargetFamily, REMOTE_RESP_OK, REMOTE_RESP_NOTSUP};
 
 pub struct RemoteV0
 {
@@ -164,6 +161,10 @@ impl BmdRemoteProtocol for RemoteV0
 	{
 		Ok(None)
 	}
+
+	fn get_target_power_state(&self) -> Result<bool> {
+		Err(eyre!("Not supported"))
+	}
 }
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV0Plus
@@ -242,6 +243,10 @@ impl BmdRemoteProtocol for RemoteV0Plus
 	fn supported_families(&self) -> Result<Option<TargetFamily>>
 	{
 		self.0.supported_families()
+	}
+
+	fn get_target_power_state(&self) -> Result<bool> {
+		self.0.get_target_power_state()
 	}
 }
 

--- a/src/serial/remote/protocol_v0.rs
+++ b/src/serial/remote/protocol_v0.rs
@@ -9,7 +9,10 @@ use log::{debug, warn};
 
 use crate::serial::bmd_rsp::BmdRspInterface;
 use crate::serial::remote::adi::{AdiV5AccessPort, AdiV5DebugPort};
-use crate::serial::remote::{Align, BmdAdiV5Protocol, BmdJtagProtocol, BmdRemoteProtocol, BmdRiscvProtocol, BmdSwdProtocol, JtagDev, REMOTE_RESP_ERR, TargetAddr64, TargetArchitecture, TargetFamily};
+use crate::serial::remote::{
+	Align, BmdAdiV5Protocol, BmdJtagProtocol, BmdRemoteProtocol, BmdRiscvProtocol, BmdSwdProtocol, JtagDev,
+	REMOTE_RESP_ERR, TargetAddr64, TargetArchitecture, TargetFamily,
+};
 
 pub struct RemoteV0
 {

--- a/src/serial/remote/protocol_v0.rs
+++ b/src/serial/remote/protocol_v0.rs
@@ -9,7 +9,7 @@ use log::{debug, warn};
 
 use crate::serial::bmd_rsp::BmdRspInterface;
 use crate::serial::remote::adi::{AdiV5AccessPort, AdiV5DebugPort};
-use crate::serial::remote::{Align, BmdAdiV5Protocol, BmdJtagProtocol, BmdRemoteProtocol, BmdRiscvProtocol, BmdSwdProtocol, JtagDev, REMOTE_RESP_ERR, TargetAddr64, TargetArchitecture, TargetFamily, REMOTE_RESP_OK, REMOTE_RESP_NOTSUP};
+use crate::serial::remote::{Align, BmdAdiV5Protocol, BmdJtagProtocol, BmdRemoteProtocol, BmdRiscvProtocol, BmdSwdProtocol, JtagDev, REMOTE_RESP_ERR, TargetAddr64, TargetArchitecture, TargetFamily};
 
 pub struct RemoteV0
 {
@@ -162,7 +162,8 @@ impl BmdRemoteProtocol for RemoteV0
 		Ok(None)
 	}
 
-	fn get_target_power_state(&self) -> Result<bool> {
+	fn get_target_power_state(&self) -> Result<bool>
+	{
 		Err(eyre!("Not supported"))
 	}
 }
@@ -245,7 +246,8 @@ impl BmdRemoteProtocol for RemoteV0Plus
 		self.0.supported_families()
 	}
 
-	fn get_target_power_state(&self) -> Result<bool> {
+	fn get_target_power_state(&self) -> Result<bool>
+	{
 		self.0.get_target_power_state()
 	}
 }

--- a/src/serial/remote/protocol_v1.rs
+++ b/src/serial/remote/protocol_v1.rs
@@ -110,6 +110,10 @@ impl BmdRemoteProtocol for RemoteV1
 	{
 		self.0.supported_families()
 	}
+
+	fn get_target_power_state(&self) -> Result<bool> {
+		self.0.get_target_power_state()
+	}
 }
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV1ADIv5

--- a/src/serial/remote/protocol_v1.rs
+++ b/src/serial/remote/protocol_v1.rs
@@ -111,7 +111,8 @@ impl BmdRemoteProtocol for RemoteV1
 		self.0.supported_families()
 	}
 
-	fn get_target_power_state(&self) -> Result<bool> {
+	fn get_target_power_state(&self) -> Result<bool>
+	{
 		self.0.get_target_power_state()
 	}
 }

--- a/src/serial/remote/protocol_v2.rs
+++ b/src/serial/remote/protocol_v2.rs
@@ -10,7 +10,10 @@ use log::{debug, warn};
 use crate::serial::bmd_rsp::BmdRspInterface;
 use crate::serial::remote::protocol_v0::RemoteV0JTAG;
 use crate::serial::remote::protocol_v1::RemoteV1;
-use crate::serial::remote::{BmdAdiV5Protocol, BmdJtagProtocol, BmdRemoteProtocol, BmdRiscvProtocol, BmdSwdProtocol, JtagDev, REMOTE_RESP_ERR, TargetArchitecture, TargetFamily, REMOTE_RESP_OK};
+use crate::serial::remote::{
+	BmdAdiV5Protocol, BmdJtagProtocol, BmdRemoteProtocol, BmdRiscvProtocol, BmdSwdProtocol, JtagDev, REMOTE_RESP_ERR,
+	REMOTE_RESP_OK, TargetArchitecture, TargetFamily,
+};
 
 pub struct RemoteV2(RemoteV1);
 

--- a/src/serial/remote/protocol_v2.rs
+++ b/src/serial/remote/protocol_v2.rs
@@ -18,7 +18,7 @@ pub struct RemoteV2JTAG(RemoteV0JTAG);
 
 const REMOTE_JTAG_INIT: &str = "!JS#";
 /// This command asks the probe if the power is used
-const REMOTE_PWR_GET: &str = "!GV#";
+const REMOTE_TARGET_VOLTAGE: &str = "!Gp#";
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV2
 {
@@ -121,7 +121,7 @@ impl BmdRemoteProtocol for RemoteV2
 
 	fn get_target_power_state(&self) -> Result<bool>
 	{
-		self.interface().buffer_write(REMOTE_PWR_GET)?;
+		self.interface().buffer_write(REMOTE_TARGET_VOLTAGE)?;
 		let buffer = self.interface().buffer_read()?;
 
 		if buffer.is_empty() || buffer.as_bytes()[0] != REMOTE_RESP_OK {

--- a/src/serial/remote/protocol_v2.rs
+++ b/src/serial/remote/protocol_v2.rs
@@ -119,7 +119,8 @@ impl BmdRemoteProtocol for RemoteV2
 		self.0.supported_families()
 	}
 
-	fn get_target_power_state(&self) -> Result<bool> {
+	fn get_target_power_state(&self) -> Result<bool>
+	{
 		self.interface().buffer_write(REMOTE_PWR_GET)?;
 		let buffer = self.interface().buffer_read()?;
 

--- a/src/serial/remote/protocol_v2.rs
+++ b/src/serial/remote/protocol_v2.rs
@@ -21,7 +21,9 @@ pub struct RemoteV2JTAG(RemoteV0JTAG);
 
 const REMOTE_JTAG_INIT: &str = "!JS#";
 /// This command asks the probe if the power is used
-const REMOTE_TARGET_VOLTAGE: &str = "!Gp#";
+#[allow(dead_code)]
+const REMOTE_TARGET_VOLTAGE: &str = "!GV#";
+const REMOTE_GET_TARGET_POWER_STATE: &str = "!Gp#";
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV2
 {
@@ -124,7 +126,7 @@ impl BmdRemoteProtocol for RemoteV2
 
 	fn get_target_power_state(&self) -> Result<bool>
 	{
-		self.interface().buffer_write(REMOTE_TARGET_VOLTAGE)?;
+		self.interface().buffer_write(REMOTE_GET_TARGET_POWER_STATE)?;
 		let buffer = self.interface().buffer_read()?;
 
 		if buffer.is_empty() || buffer.as_bytes()[0] != REMOTE_RESP_OK {

--- a/src/serial/remote/protocol_v3.rs
+++ b/src/serial/remote/protocol_v3.rs
@@ -107,7 +107,8 @@ impl BmdRemoteProtocol for RemoteV3
 		self.0.supported_families()
 	}
 
-	fn get_target_power_state(&self) -> Result<bool> {
+	fn get_target_power_state(&self) -> Result<bool>
+	{
 		self.0.get_target_power_state()
 	}
 }

--- a/src/serial/remote/protocol_v3.rs
+++ b/src/serial/remote/protocol_v3.rs
@@ -106,6 +106,10 @@ impl BmdRemoteProtocol for RemoteV3
 	{
 		self.0.supported_families()
 	}
+
+	fn get_target_power_state(&self) -> Result<bool> {
+		self.0.get_target_power_state()
+	}
 }
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV3ADIv5

--- a/src/serial/remote/protocol_v4.rs
+++ b/src/serial/remote/protocol_v4.rs
@@ -224,7 +224,8 @@ impl BmdRemoteProtocol for RemoteV4
 		}
 	}
 
-	fn get_target_power_state(&self) -> Result<bool> {
+	fn get_target_power_state(&self) -> Result<bool>
+	{
 		self.inner_protocol.get_target_power_state()
 	}
 }

--- a/src/serial/remote/protocol_v4.rs
+++ b/src/serial/remote/protocol_v4.rs
@@ -223,6 +223,10 @@ impl BmdRemoteProtocol for RemoteV4
 			Ok(Some(families.into()))
 		}
 	}
+
+	fn get_target_power_state(&self) -> Result<bool> {
+		self.inner_protocol.get_target_power_state()
+	}
 }
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV4ADIv5


### PR DESCRIPTION
As per #46 , my attempt to take a stab on this.

- As discussed, this command should only attempt a call on v2 and higher.
- As discussed, makes only sense to target 1 BMP

Open question: 
- `println!("Device target power state: {}", power);`, do we want to return `println!` or `info!` here?