### PR TITLE
Enhance `bmputil-cli target power`

### DIFF
--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -438,10 +438,15 @@ fn power_command(cli_args: &CliArguments) -> Result<()>
 	// Otherwise, turn the result set into a list and go through them displaying them
 	let device = results.pop_single("power").map_err(|kind| kind.error())?;
 	let remote = device.bmd_serial_interface()?.remote()?;
+	
+	match remote.get_target_power_state() {
+		Ok(power) => info!("Device target power state: {}", power),
+		Err(e) => warn!("Failed to retrieve target power state: {}", e),
+	};	
 
-	let power = remote.get_target_power_state()?;
+	let voltage = remote.get_target_voltage()?;
+	info!("Target voltage: {}V", voltage);
 
-	info!("Device target power state: {}", power);
 
 	Ok(())
 }

--- a/src/bin/bmputil-cli.rs
+++ b/src/bin/bmputil-cli.rs
@@ -438,15 +438,14 @@ fn power_command(cli_args: &CliArguments) -> Result<()>
 	// Otherwise, turn the result set into a list and go through them displaying them
 	let device = results.pop_single("power").map_err(|kind| kind.error())?;
 	let remote = device.bmd_serial_interface()?.remote()?;
-	
+
 	match remote.get_target_power_state() {
 		Ok(power) => info!("Device target power state: {}", power),
 		Err(e) => warn!("Failed to retrieve target power state: {}", e),
-	};	
+	};
 
 	let voltage = remote.get_target_voltage()?;
 	info!("Target voltage: {}V", voltage);
-
 
 	Ok(())
 }

--- a/src/serial/remote/mod.rs
+++ b/src/serial/remote/mod.rs
@@ -113,6 +113,8 @@ pub trait BmdRemoteProtocol
 	fn supported_families(&self) -> Result<Option<TargetFamily>>;
 	fn get_target_power_state(&self) -> Result<bool>;
 	fn get_target_voltage(&self) -> Result<f32>;
+	fn get_srst_val(&self) -> Result<bool>;
+	fn get_target_supply_power(&self) -> Result<bool>;
 }
 
 /// Types implementing this trait provide raw SWD access to targets over the BMD remote protocol

--- a/src/serial/remote/mod.rs
+++ b/src/serial/remote/mod.rs
@@ -112,6 +112,7 @@ pub trait BmdRemoteProtocol
 	fn supported_architectures(&self) -> Result<Option<TargetArchitecture>>;
 	fn supported_families(&self) -> Result<Option<TargetFamily>>;
 	fn get_target_power_state(&self) -> Result<bool>;
+	fn get_target_voltage(&self) -> Result<f32>;
 }
 
 /// Types implementing this trait provide raw SWD access to targets over the BMD remote protocol

--- a/src/serial/remote/protocol_v1.rs
+++ b/src/serial/remote/protocol_v1.rs
@@ -115,6 +115,10 @@ impl BmdRemoteProtocol for RemoteV1
 	{
 		self.0.get_target_power_state()
 	}
+
+	fn get_target_voltage(&self) -> Result<f32> {
+		self.0.get_target_voltage()
+	}
 }
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV1ADIv5

--- a/src/serial/remote/protocol_v1.rs
+++ b/src/serial/remote/protocol_v1.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+// SPDX-FileContributor: Modified by P-Storm <pauldeman@gmail.com>
 
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -116,8 +117,19 @@ impl BmdRemoteProtocol for RemoteV1
 		self.0.get_target_power_state()
 	}
 
-	fn get_target_voltage(&self) -> Result<f32> {
+	fn get_target_voltage(&self) -> Result<f32>
+	{
 		self.0.get_target_voltage()
+	}
+
+	fn get_srst_val(&self) -> Result<bool>
+	{
+		self.0.get_srst_val()
+	}
+
+	fn get_target_supply_power(&self) -> Result<bool>
+	{
+		self.0.get_target_supply_power()
 	}
 }
 

--- a/src/serial/remote/protocol_v2.rs
+++ b/src/serial/remote/protocol_v2.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+// SPDX-FileContributor: Modified by P-Storm <pauldeman@gmail.com>
 
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -138,8 +139,19 @@ impl BmdRemoteProtocol for RemoteV2
 		Ok(buffer.as_bytes()[1] == b'1')
 	}
 
-	fn get_target_voltage(&self) -> Result<f32> {
+	fn get_target_voltage(&self) -> Result<f32>
+	{
 		self.0.get_target_voltage()
+	}
+
+	fn get_srst_val(&self) -> Result<bool>
+	{
+		self.0.get_srst_val()
+	}
+
+	fn get_target_supply_power(&self) -> Result<bool>
+	{
+		self.0.get_target_supply_power()
 	}
 }
 

--- a/src/serial/remote/protocol_v2.rs
+++ b/src/serial/remote/protocol_v2.rs
@@ -21,8 +21,6 @@ pub struct RemoteV2JTAG(RemoteV0JTAG);
 
 const REMOTE_JTAG_INIT: &str = "!JS#";
 /// This command asks the probe if the power is used
-#[allow(dead_code)]
-const REMOTE_TARGET_VOLTAGE: &str = "!GV#";
 const REMOTE_GET_TARGET_POWER_STATE: &str = "!Gp#";
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV2
@@ -138,6 +136,10 @@ impl BmdRemoteProtocol for RemoteV2
 		}
 
 		Ok(buffer.as_bytes()[1] == b'1')
+	}
+
+	fn get_target_voltage(&self) -> Result<f32> {
+		self.0.get_target_voltage()
 	}
 }
 

--- a/src/serial/remote/protocol_v3.rs
+++ b/src/serial/remote/protocol_v3.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+// SPDX-FileContributor: Modified by P-Storm <pauldeman@gmail.com>
 
 use std::sync::{Arc, Mutex, MutexGuard};
 
@@ -112,8 +113,19 @@ impl BmdRemoteProtocol for RemoteV3
 		self.0.get_target_power_state()
 	}
 
-	fn get_target_voltage(&self) -> Result<f32> {
+	fn get_target_voltage(&self) -> Result<f32>
+	{
 		self.0.get_target_voltage()
+	}
+
+	fn get_srst_val(&self) -> Result<bool>
+	{
+		self.0.get_srst_val()
+	}
+
+	fn get_target_supply_power(&self) -> Result<bool>
+	{
+		self.0.get_target_supply_power()
 	}
 }
 

--- a/src/serial/remote/protocol_v3.rs
+++ b/src/serial/remote/protocol_v3.rs
@@ -111,6 +111,10 @@ impl BmdRemoteProtocol for RemoteV3
 	{
 		self.0.get_target_power_state()
 	}
+
+	fn get_target_voltage(&self) -> Result<f32> {
+		self.0.get_target_voltage()
+	}
 }
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV3ADIv5

--- a/src/serial/remote/protocol_v4.rs
+++ b/src/serial/remote/protocol_v4.rs
@@ -228,6 +228,10 @@ impl BmdRemoteProtocol for RemoteV4
 	{
 		self.inner_protocol.get_target_power_state()
 	}
+
+	fn get_target_voltage(&self) -> Result<f32> {
+		self.inner_protocol.get_target_voltage()
+	}
 }
 
 impl From<Arc<Mutex<BmdRspInterface>>> for RemoteV4ADIv5

--- a/src/serial/remote/protocol_v4.rs
+++ b/src/serial/remote/protocol_v4.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 // SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
+// SPDX-FileContributor: Modified by P-Storm <pauldeman@gmail.com>
 
 use std::fmt::Display;
 use std::sync::{Arc, Mutex, MutexGuard};
@@ -229,8 +230,19 @@ impl BmdRemoteProtocol for RemoteV4
 		self.inner_protocol.get_target_power_state()
 	}
 
-	fn get_target_voltage(&self) -> Result<f32> {
+	fn get_target_voltage(&self) -> Result<f32>
+	{
 		self.inner_protocol.get_target_voltage()
+	}
+
+	fn get_srst_val(&self) -> Result<bool>
+	{
+		self.inner_protocol.get_srst_val()
+	}
+
+	fn get_target_supply_power(&self) -> Result<bool>
+	{
+		self.inner_protocol.get_target_supply_power()
 	}
 }
 


### PR DESCRIPTION
Adding more information for command `bmputil-cli target power`:

```
[2025-07-29T13:38:30Z INFO  bmputil_cli] Device target power state: false
[2025-07-29T13:38:30Z INFO  bmputil_cli] Target voltage: 0V
```

Also made `Device target power state` a warning if the version is too low.

Added preparation for `REMOTE_SRST` and `REMOTE_PWR`