### PR TITLE
Feature: Intel HEX loader

### DIFF
--- a/src/firmware_file/ihex.rs
+++ b/src/firmware_file/ihex.rs
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2025 1BitSquared <info@1bitsquared.com>
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
 
-use std::{fs::File, io::ErrorKind};
-use std::io::{Read, Seek};
+use std::fs::File;
+use std::io::{ErrorKind, Read, Seek};
 
 use color_eyre::eyre::{Report, Result, eyre};
 use log::debug;
@@ -45,7 +45,7 @@ impl TryFrom<File> for IntelHexFirmwareFile
 		// Set up a vec to receive the records, and a buffer to receive newline characters
 		let mut records = Vec::new();
 		let mut buf = [0];
-		let mut eof =  false;
+		let mut eof = false;
 		while !eof {
 			// Try to read a record and stuff it into the records vec
 			records.push(IntelHexRecord::try_from(&mut file)?);
@@ -135,7 +135,7 @@ impl TryFrom<&mut File> for IntelHexRecord
 		for idx in 0..len {
 			let begin = idx * 2;
 			let end = begin + 2;
-			bytes[idx] =  u8::from_str_radix(str::from_utf8(&bytes[begin..end])?, 16)?;
+			bytes[idx] = u8::from_str_radix(str::from_utf8(&bytes[begin..end])?, 16)?;
 			actual_checksum = actual_checksum.wrapping_add(bytes[idx]);
 		}
 
@@ -152,10 +152,14 @@ impl TryFrom<&mut File> for IntelHexRecord
 		let mut data = [0xff; 255];
 		data[0..len].copy_from_slice(&bytes[0..len]);
 
+		// Convert the record type and do any record-specific validation
+		let record_type = IntelHexRecordType::try_from(record_type)?;
+		record_type.validate_byte_count(byte_count)?;
+
 		Ok(Self {
 			byte_count,
 			address,
-			record_type: IntelHexRecordType::try_from(record_type)?,
+			record_type,
 			data,
 		})
 	}
@@ -175,6 +179,37 @@ impl TryFrom<u8> for IntelHexRecordType
 			4 => Ok(Self::ExtendedLinearAddress),
 			5 => Ok(Self::StartLinearAddress),
 			_ => Err(eyre!("Invalid record type {value} found")),
+		}
+	}
+}
+
+impl IntelHexRecordType
+{
+	pub fn validate_byte_count(&self, byte_count: u8) -> Result<()>
+	{
+		match self {
+			Self::EndOfFile => {
+				if byte_count == 0 {
+					Ok(())
+				} else {
+					Err(eyre!("Invalid EOF, expected 0 bytes in record, got {byte_count}"))
+				}
+			},
+			Self::ExtendedSegmentAddress | Self::ExtendedLinearAddress => {
+				if byte_count == 2 {
+					Ok(())
+				} else {
+					Err(eyre!("Invalid extended address record, expected 2 bytes, got {byte_count}"))
+				}
+			},
+			Self::StartSegmentAddress | Self::StartLinearAddress => {
+				if byte_count == 4 {
+					Ok(())
+				} else {
+					Err(eyre!("Invalid extended address record, expected 4 bytes, got {byte_count}"))
+				}
+			},
+			_ => Ok(()),
 		}
 	}
 }

--- a/src/firmware_file/ihex.rs
+++ b/src/firmware_file/ihex.rs
@@ -3,12 +3,34 @@
 // SPDX-FileContributor: Written by Rachel Mant <git@dragonmux.network>
 
 use std::fs::File;
+use std::io::Read;
 
+use color_eyre::eyre::{Report, Result, eyre};
 use owo_colors::OwoColorize;
 
 use super::FirmwareStorage;
 
 pub struct IntelHexFirmwareFile {}
+
+struct IntelHexRecord
+{
+	byte_count: u8,
+	address: u16,
+	record_type: IntelHexRecordType,
+	data: [u8; 255],
+}
+
+#[repr(u8)]
+#[non_exhaustive]
+enum IntelHexRecordType
+{
+	Data = 0x00,
+	EndOfFile = 0x01,
+	ExtendedSegmentAddress = 0x02,
+	StartSegmentAddress = 0x03,
+	ExtendedLinearAddress = 0x04,
+	StartLinearAddress = 0x05,
+}
 
 impl From<File> for IntelHexFirmwareFile
 {
@@ -34,5 +56,91 @@ impl FirmwareStorage for IntelHexFirmwareFile
 	fn firmware_data(&self) -> &[u8]
 	{
 		&[]
+	}
+}
+
+impl IntelHexRecord
+{
+	pub fn new(file: &mut File) -> Result<Self>
+	{
+		let mut data = [0];
+		// Consume bytes from `file` till we find an opening `:`
+		loop {
+			// This'll explode with an unexpected EOF error if we can't find a `:`
+			file.read_exact(&mut data)?;
+			if data[0] == b':' {
+				break;
+			}
+		}
+
+		// Set up the line checksum
+		let mut actual_checksum = 0u8;
+
+		// Read 2 bytes to interpret as the byte count and convert from ASCII hex
+		let mut data = [0; 2];
+		file.read_exact(&mut data)?;
+		let byte_count = u8::from_str_radix(str::from_utf8(&data)?, 16)?;
+		actual_checksum += byte_count;
+
+		// Read 4 bytes to interpret as an address
+		let mut data = [0; 4];
+		file.read_exact(&mut data)?;
+		let address = u16::from_str_radix(str::from_utf8(&data)?, 16)?;
+		actual_checksum += ((address >> 8) as u8) + (address as u8);
+
+		// Read 2 bytes to interpret as the record type
+		let mut data = [0; 2];
+		file.read_exact(&mut data)?;
+		let record_type = u8::from_str_radix(str::from_utf8(&data)?, 16)?;
+		actual_checksum += record_type;
+
+		// Read byte_count byte pairs into a buffer sized to take it
+		let len = byte_count as usize;
+		let mut bytes = vec![0; len * 2];
+		file.read_exact(&mut bytes[0..(len * 2)])?;
+		// De-hexify the bytes
+		for idx in 0..len {
+			let begin = idx * 2;
+			let end = begin + 2;
+			bytes[idx] =  u8::from_str_radix(str::from_utf8(&bytes[begin..end])?, 16)?;
+			actual_checksum += bytes[idx];
+		}
+
+		// Read 2 bytes to interpret as the checksum
+		let mut data = [0; 2];
+		file.read_exact(&mut data)?;
+		let expected_checksum = u8::from_str_radix(str::from_utf8(&data)?, 16)?;
+		if expected_checksum != !actual_checksum {
+			return Err(eyre!("Checksum invalid for ihex record"));
+		}
+
+		// Make a buffer to hold the decoded data in and copy the finalised data into it
+		let mut data = [0xff; 255];
+		data[0..len].copy_from_slice(&bytes[0..len]);
+
+		Ok(Self {
+			byte_count,
+			address,
+			record_type: IntelHexRecordType::try_from(record_type)?,
+			data,
+		})
+	}
+}
+
+impl TryFrom<u8> for IntelHexRecordType
+{
+	type Error = Report;
+
+	fn try_from(value: u8) -> Result<Self>
+	{
+		match value {
+			0 => Ok(Self::Data),
+			1 => Ok(Self::EndOfFile),
+			2 => Ok(Self::ExtendedSegmentAddress),
+			3 => Ok(Self::StartSegmentAddress),
+			4 => Ok(Self::ExtendedLinearAddress),
+			5 => Ok(Self::StartLinearAddress),
+			_ => Err(eyre!("Invalid record type {value} found")),
+		}
 	}
 }

--- a/src/firmware_file/ihex.rs
+++ b/src/firmware_file/ihex.rs
@@ -157,7 +157,7 @@ impl FirmwareStorage for IntelHexFirmwareFile
 {
 	fn load_address(&self) -> Option<u32>
 	{
-		None
+		self.segments.first_key_value().map(|(&address, _)| address)
 	}
 
 	fn firmware_data(&self) -> &[u8]

--- a/src/firmware_file/mod.rs
+++ b/src/firmware_file/mod.rs
@@ -45,7 +45,7 @@ impl FirmwareFile
 		let storage: Box<dyn FirmwareStorage> = if &signature == b"\x7fELF" {
 			Box::new(ELFFirmwareFile::try_from(file)?)
 		} else if &signature[0..1] == b":" {
-			Box::new(IntelHexFirmwareFile::from(file))
+			Box::new(IntelHexFirmwareFile::try_from(file)?)
 		} else {
 			Box::new(RawFirmwareFile::try_from(file)?)
 		};

--- a/src/firmware_type.rs
+++ b/src/firmware_type.rs
@@ -6,11 +6,13 @@
 use std::array::TryFromSliceError;
 use std::fmt::Display;
 
-use clap::{ValueEnum, builder::PossibleValue};
+use clap::ValueEnum;
+use clap::builder::PossibleValue;
 use color_eyre::eyre::{Context, Result, eyre};
 use log::debug;
 
-use crate::{bmp::BmpPlatform, firmware_file::FirmwareFile};
+use crate::bmp::BmpPlatform;
+use crate::firmware_file::FirmwareFile;
 
 /// Represents a conceptual Vector Table for Armv7 processors.
 pub struct Armv7mVectorTable<'b>
@@ -73,21 +75,19 @@ impl FirmwareType
 	/// This function panics if `firmware.len() < 8`.
 	pub fn detect_from_firmware(platform: BmpPlatform, firmware_file: &FirmwareFile) -> Result<Self>
 	{
-        // If the firmware image has a load address
-        if let Some(load_address) = firmware_file.load_address() {
-            // Check if the address is the bootloader area for the platform
-            let boot_start = platform.load_address(Self::Bootloader);
-            return Ok(
-                if load_address == boot_start {
-                    Self::Bootloader
-                } else {
-                    Self::Application
-                }
-            );
-        }
+		// If the firmware image has a load address
+		if let Some(load_address) = firmware_file.load_address() {
+			// Check if the address is the bootloader area for the platform
+			let boot_start = platform.load_address(Self::Bootloader);
+			return Ok(if load_address == boot_start {
+				Self::Bootloader
+			} else {
+				Self::Application
+			});
+		}
 
-        // If the firmware doesn't have a known load address, fall back to figuring it out
-        // from the NVIC table at the front of the image
+		// If the firmware doesn't have a known load address, fall back to figuring it out
+		// from the NVIC table at the front of the image
 		let buffer = &firmware_file.data()[0..(4 * 2)];
 
 		let vector_table = Armv7mVectorTable::from_bytes(buffer);


### PR DESCRIPTION
In this PR we address the Intel HEX support that has till now just been a stub that bombs the tool out. This completes the trifecta of formats the tool understands (raw .bin, ELF, ihex) and can use as a data source for the firmware.

This is mostly just for completeness sake as the build system is capable of producing a .hex of the firmware. The preference is still for users to have the tool work with ELF files as they're the most information-complete and robust mechanism available.